### PR TITLE
replace axios with local data service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@radix-ui/react-toggle-group": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-table": "^8.11.6",
-        "axios": "^1.6.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "club-san-agustin": "file:",
@@ -2628,11 +2627,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2692,16 +2686,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2815,6 +2799,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3214,17 +3199,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3513,14 +3487,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -3573,6 +3539,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3695,6 +3662,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3703,6 +3671,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3738,6 +3707,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3749,6 +3719,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4356,25 +4327,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4403,20 +4355,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4492,6 +4430,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4523,6 +4462,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -4669,6 +4609,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4739,6 +4680,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4750,6 +4692,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5468,6 +5411,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5490,25 +5434,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -6147,11 +6072,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -9261,11 +9181,6 @@
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -9294,16 +9209,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "dev": true
-    },
-    "axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "axobject-query": {
       "version": "4.1.0",
@@ -9375,6 +9280,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -9496,7 +9402,6 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.0.1",
-        "axios": "^1.6.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "club-san-agustin": "file:",
@@ -11014,11 +10919,6 @@
           "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
           "dev": true
         },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
         "autoprefixer": {
           "version": "10.4.21",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -11047,16 +10947,6 @@
           "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
           "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
           "dev": true
-        },
-        "axios": {
-          "version": "1.8.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-          "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
         },
         "axobject-query": {
           "version": "4.1.0",
@@ -11128,6 +11018,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
           "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+          "dev": true,
           "requires": {
             "es-errors": "^1.3.0",
             "function-bind": "^1.1.2"
@@ -11405,14 +11296,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "combined-stream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
         "commander": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -11610,11 +11493,6 @@
             "object-keys": "^1.1.1"
           }
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-        },
         "detect-node-es": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -11661,6 +11539,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
           "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+          "dev": true,
           "requires": {
             "call-bind-apply-helpers": "^1.0.1",
             "es-errors": "^1.3.0",
@@ -11765,12 +11644,14 @@
         "es-define-property": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+          "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+          "dev": true
         },
         "es-errors": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+          "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+          "dev": true
         },
         "es-iterator-helpers": {
           "version": "1.2.1",
@@ -11800,6 +11681,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
           "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+          "dev": true,
           "requires": {
             "es-errors": "^1.3.0"
           }
@@ -11808,6 +11690,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
           "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+          "dev": true,
           "requires": {
             "es-errors": "^1.3.0",
             "get-intrinsic": "^1.2.6",
@@ -12263,11 +12146,6 @@
           "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
           "dev": true
         },
-        "follow-redirects": {
-          "version": "1.15.9",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-          "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-        },
         "for-each": {
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -12284,17 +12162,6 @@
           "requires": {
             "cross-spawn": "^7.0.6",
             "signal-exit": "^4.0.1"
-          }
-        },
-        "form-data": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-          "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "es-set-tostringtag": "^2.1.0",
-            "mime-types": "^2.1.12"
           }
         },
         "fraction.js": {
@@ -12344,6 +12211,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
           "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+          "dev": true,
           "requires": {
             "call-bind-apply-helpers": "^1.0.2",
             "es-define-property": "^1.0.1",
@@ -12366,6 +12234,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
           "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+          "dev": true,
           "requires": {
             "dunder-proto": "^1.0.1",
             "es-object-atoms": "^1.0.0"
@@ -12465,7 +12334,8 @@
         "gopd": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+          "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.2.11",
@@ -12511,12 +12381,14 @@
         "has-symbols": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+          "dev": true
         },
         "has-tostringtag": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
           "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.3"
           }
@@ -13010,7 +12882,8 @@
         "math-intrinsics": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+          "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+          "dev": true
         },
         "merge2": {
           "version": "1.4.1",
@@ -13024,19 +12897,6 @@
           "requires": {
             "braces": "^3.0.3",
             "picomatch": "^2.3.1"
-          }
-        },
-        "mime-db": {
-          "version": "1.52.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-          "version": "2.1.35",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-          "requires": {
-            "mime-db": "1.52.0"
           }
         },
         "minimatch": {
@@ -13425,11 +13285,6 @@
             "object-assign": "^4.1.1",
             "react-is": "^16.13.1"
           }
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "punycode": {
           "version": "2.3.1",
@@ -14702,14 +14557,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -14907,11 +14754,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-    },
     "detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -14958,6 +14800,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "requires": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -15062,12 +14905,14 @@
     "es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
     },
     "es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
     },
     "es-iterator-helpers": {
       "version": "1.2.1",
@@ -15097,6 +14942,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -15105,6 +14951,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -15560,11 +15407,6 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
-    },
     "for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -15581,17 +15423,6 @@
       "requires": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
-      }
-    },
-    "form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
       }
     },
     "fraction.js": {
@@ -15641,6 +15472,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "requires": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -15663,6 +15495,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "requires": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -15762,7 +15595,8 @@
     "gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.11",
@@ -15808,12 +15642,14 @@
     "has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.3"
       }
@@ -16307,7 +16143,8 @@
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -16321,19 +16158,6 @@
       "requires": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
@@ -16722,11 +16546,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@radix-ui/react-toggle-group": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-table": "^8.11.6",
-    "axios": "^1.6.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "club-san-agustin": "file:",

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,14 +1,6 @@
-"use client"
-
 import { ApiProvider } from '@/lib/api/context'
-import ApiStatusChecker from '@/components/api-status-checker'
 import { ReactNode } from 'react'
 
 export function Providers({ children }: { children: ReactNode }) {
-  return (
-    <ApiProvider>
-      {children}
-      <ApiStatusChecker />
-    </ApiProvider>
-  )
+  return <ApiProvider>{children}</ApiProvider>
 }

--- a/src/data/cadete-b.json
+++ b/src/data/cadete-b.json
@@ -1,0 +1,69 @@
+{
+  "teams": [
+    { "id": "1", "nombre": "Cadete B", "categoria": "Cadete" }
+  ],
+  "players": [
+    { "id": "1", "equipoId": "1", "nombre": "Juan", "apellidos": "García López", "posicion": "Delantero", "dorsal": 9, "asistencia": "95%" },
+    { "id": "2", "equipoId": "1", "nombre": "Miguel", "apellidos": "Fernández Ruiz", "posicion": "Centrocampista", "dorsal": 8, "asistencia": "90%" },
+    { "id": "3", "equipoId": "1", "nombre": "Carlos", "apellidos": "Martínez Sanz", "posicion": "Defensa", "dorsal": 4, "asistencia": "85%" },
+    { "id": "4", "equipoId": "1", "nombre": "David", "apellidos": "López Gómez", "posicion": "Portero", "dorsal": 1, "asistencia": "100%" },
+    { "id": "5", "equipoId": "1", "nombre": "Javier", "apellidos": "Sánchez Pérez", "posicion": "Defensa", "dorsal": 2, "asistencia": "80%" },
+    { "id": "6", "equipoId": "1", "nombre": "Alejandro", "apellidos": "González Díaz", "posicion": "Centrocampista", "dorsal": 6, "asistencia": "85%" },
+    { "id": "7", "equipoId": "1", "nombre": "Daniel", "apellidos": "Pérez Martín", "posicion": "Delantero", "dorsal": 11, "asistencia": "90%" }
+  ],
+  "attendance": [
+    {
+      "id": "1",
+      "equipoId": "1",
+      "fecha": "09/04/2025",
+      "tipo": "Entrenamiento regular",
+      "asistencia": "90%",
+      "jugadores": [
+        { "id": "1", "nombre": "Juan García", "asistio": true, "motivo": null },
+        { "id": "2", "nombre": "Miguel Fernández", "asistio": true, "motivo": null },
+        { "id": "3", "nombre": "Carlos Martínez", "asistio": false, "motivo": "Lesión" },
+        { "id": "4", "nombre": "David López", "asistio": true, "motivo": null }
+      ]
+    },
+    {
+      "id": "2",
+      "equipoId": "1",
+      "fecha": "07/04/2025",
+      "tipo": "Entrenamiento regular",
+      "asistencia": "85%",
+      "jugadores": [
+        { "id": "1", "nombre": "Juan García", "asistio": true, "motivo": null },
+        { "id": "2", "nombre": "Miguel Fernández", "asistio": false, "motivo": "Estudios" },
+        { "id": "3", "nombre": "Carlos Martínez", "asistio": false, "motivo": "Lesión" },
+        { "id": "4", "nombre": "David López", "asistio": true, "motivo": null }
+      ]
+    },
+    {
+      "id": "3",
+      "equipoId": "1",
+      "fecha": "04/04/2025",
+      "tipo": "Entrenamiento regular",
+      "asistencia": "80%",
+      "jugadores": [
+        { "id": "1", "nombre": "Juan García", "asistio": true, "motivo": null },
+        { "id": "2", "nombre": "Miguel Fernández", "asistio": true, "motivo": null },
+        { "id": "3", "nombre": "Carlos Martínez", "asistio": false, "motivo": "Lesión" },
+        { "id": "4", "nombre": "David López", "asistio": false, "motivo": "Viaje" }
+      ]
+    },
+    {
+      "id": "4",
+      "equipoId": "1",
+      "fecha": "02/04/2025",
+      "tipo": "Entrenamiento regular",
+      "asistencia": "95%",
+      "jugadores": [
+        { "id": "1", "nombre": "Juan García", "asistio": true, "motivo": null },
+        { "id": "2", "nombre": "Miguel Fernández", "asistio": true, "motivo": null },
+        { "id": "3", "nombre": "Carlos Martínez", "asistio": true, "motivo": null },
+        { "id": "4", "nombre": "David López", "asistio": true, "motivo": null }
+      ]
+    }
+  ],
+  "matches": []
+}

--- a/src/lib/api/context.js
+++ b/src/lib/api/context.js
@@ -1,15 +1,10 @@
 "use client"
 
-import React, { createContext, useContext, useState, useEffect } from 'react'
-import axios from 'axios'
+import React, { createContext, useContext } from 'react'
+import { getTeams, getPlayers, getPlayerById, getAttendance } from '@/lib/data-service'
 
-// URL base de la API
-const API_URL = 'https://agus-back.onrender.com/api'
-
-// Crear el contexto
 const ApiContext = createContext(null)
 
-// Hook personalizado para usar el contexto
 export const useApi = () => {
   const context = useContext(ApiContext)
   if (!context) {
@@ -18,147 +13,40 @@ export const useApi = () => {
   return context
 }
 
-// Proveedor del contexto
 export function ApiProvider({ children }) {
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState(null)
-  const [apiStatus, setApiStatus] = useState({ status: 'unknown', message: 'Verificando conexión...' })
-
-  // Verificar el estado de la API al cargar
-  useEffect(() => {
-    checkApiStatus()
-  }, [])
-
-  // Función para verificar el estado de la API
-  const checkApiStatus = async () => {
-    try {
-      setIsLoading(true)
-      const response = await axios.get(`${API_URL}/status`)
-      setApiStatus({
-        status: response.data.status,
-        message: response.data.message,
-        environment: response.data.environment,
-        timestamp: response.data.timestamp
-      })
-      setError(null)
-    } catch (err) {
-      setApiStatus({
-        status: 'offline',
-        message: 'No se pudo conectar con la API'
-      })
-      setError('Error al conectar con la API')
-      console.error('Error al verificar estado de la API:', err)
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  // Función genérica para realizar peticiones a la API
-  const apiRequest = async (method, endpoint, data = null) => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      
-      const config = {
-        method,
-        url: `${API_URL}${endpoint}`,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }
-      
-      if (data && (method === 'post' || method === 'put' || method === 'patch')) {
-        config.data = data
-      }
-      
-      const response = await axios(config)
-      return response.data
-    } catch (err) {
-      const errorMessage = err.response?.data?.mensaje || err.message || 'Error desconocido'
-      setError(errorMessage)
-      console.error(`Error en petición ${method.toUpperCase()} a ${endpoint}:`, err)
-      throw new Error(errorMessage)
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  // Servicios para equipos
   const equiposService = {
-    getAll: () => apiRequest('get', '/equipos'),
-    getById: (id) => apiRequest('get', `/equipos/${id}`),
-    getByTemporada: (temporadaId) => apiRequest('get', `/equipos/temporada/${temporadaId}`),
-    create: (data) => apiRequest('post', '/equipos', data),
-    update: (id, data) => apiRequest('put', `/equipos/${id}`, data),
-    delete: (id) => apiRequest('delete', `/equipos/${id}`)
+    getAll: async () => getTeams(),
+    getById: async (id) => (await getTeams()).find(e => e.id === id)
   }
 
-  // Servicios para jugadores
   const jugadoresService = {
-    getAll: () => apiRequest('get', '/jugadores'),
-    getById: (id) => apiRequest('get', `/jugadores/${id}`),
-    getByEquipo: (equipoId) => apiRequest('get', `/jugadores/equipo/${equipoId}`),
-    create: (data) => apiRequest('post', '/jugadores', data),
-    update: (id, data) => apiRequest('put', `/jugadores/${id}`, data),
-    delete: (id) => apiRequest('delete', `/jugadores/${id}`)
+    getAll: async () => getPlayers(),
+    getById: async (id) => getPlayerById(id),
+    getByEquipo: async (equipoId) => getPlayers(equipoId)
   }
 
-  // Servicios para asistencias
   const asistenciasService = {
-    getAll: () => apiRequest('get', '/asistencias'),
-    getByEquipo: (equipoId) => apiRequest('get', `/asistencias/equipo/${equipoId}`),
-    getByJugador: (jugadorId) => apiRequest('get', `/asistencias/jugador/${jugadorId}`),
-    registrar: (data) => apiRequest('post', '/asistencias', data),
-    update: (id, data) => apiRequest('put', `/asistencias/${id}`, data)
+    getAll: async () => getAttendance(),
+    getByEquipo: async (equipoId) => getAttendance({ equipoId }),
+    getByJugador: async (jugadorId) => getAttendance({ jugadorId })
   }
 
-  // Servicios para valoraciones
-  const valoracionesService = {
-    getAll: () => apiRequest('get', '/valoraciones'),
-    getByJugador: (jugadorId) => apiRequest('get', `/valoraciones/jugador/${jugadorId}`),
-    getByEquipo: (equipoId) => apiRequest('get', `/valoraciones/equipo/${equipoId}`),
-    create: (data) => apiRequest('post', '/valoraciones', data),
-    update: (id, data) => apiRequest('put', `/valoraciones/${id}`, data)
+  const emptyService = {
+    getAll: async () => []
   }
 
-  // Servicios para scouting
-  const scoutingService = {
-    getAll: () => apiRequest('get', '/scouting'),
-    getById: (id) => apiRequest('get', `/scouting/${id}`),
-    buscarPorNombre: (nombre) => apiRequest('get', `/scouting/buscar?nombre=${nombre}`),
-    create: (data) => apiRequest('post', '/scouting', data),
-    update: (id, data) => apiRequest('put', `/scouting/${id}`, data)
-  }
-
-  // Servicios para objetivos
-  const objetivosService = {
-    getAll: () => apiRequest('get', '/objetivos'),
-    getByEquipo: (equipoId) => apiRequest('get', `/objetivos/equipo/${equipoId}`),
-    create: (data) => apiRequest('post', '/objetivos', data),
-    update: (id, data) => apiRequest('put', `/objetivos/${id}`, data),
-    actualizarProgreso: (id, progreso) => apiRequest('patch', `/objetivos/${id}/progreso`, { progreso })
-  }
-
-  // Servicios para temporadas
-  const temporadasService = {
-    getAll: () => apiRequest('get', '/temporadas'),
-    getActual: () => apiRequest('get', '/temporadas/actual'),
-    create: (data) => apiRequest('post', '/temporadas', data)
-  }
-
-  // Valor del contexto
   const value = {
-    isLoading,
-    error,
-    apiStatus,
-    checkApiStatus,
+    isLoading: false,
+    error: null,
+    apiStatus: { status: 'online', message: 'Usando datos locales' },
+    checkApiStatus: async () => {},
     equipos: equiposService,
     jugadores: jugadoresService,
     asistencias: asistenciasService,
-    valoraciones: valoracionesService,
-    scouting: scoutingService,
-    objetivos: objetivosService,
-    temporadas: temporadasService
+    valoraciones: emptyService,
+    scouting: emptyService,
+    objetivos: emptyService,
+    temporadas: emptyService
   }
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>

--- a/src/lib/api/partidos.js
+++ b/src/lib/api/partidos.js
@@ -1,125 +1,17 @@
-import axios from 'axios';
+import { getMatches } from '@/lib/data-service'
 
-
-
-// URL base de la API
-const API_URL = 'https://agus-back.onrender.com/api';
-
-// Servicios para partidos
 export const partidosService = {
-  // Obtener todos los partidos
-  getPartidos: async (params = {}) => {
-    try {
-      const response = await axios.get(`${API_URL}/partidos`, { params });
-      return response;
-    } catch (error) {
-      console.error('Error al obtener partidos:', error);
-      throw error;
-    }
-  },
-  
-  // Obtener un partido por ID
-  getPartidoById: async (id) => {
-    try {
-      const response = await axios.get(`${API_URL}/partidos/${id}`);
-      return response;
-    } catch (error) {
-      console.error(`Error al obtener partido con ID ${id}:`, error);
-      throw error;
-    }
-  },
-  
-  // Crear un nuevo partido
-  createPartido: async (data) => {
-    try {
-      const response = await axios.post(`${API_URL}/partidos`, data);
-      return response;
-    } catch (error) {
-      console.error('Error al crear partido:', error);
-      throw error;
-    }
-  },
-  
-  // Actualizar un partido existente
-  updatePartido: async (id, data) => {
-    try {
-      const response = await axios.put(`${API_URL}/partidos/${id}`, data);
-      return response;
-    } catch (error) {
-      console.error(`Error al actualizar partido con ID ${id}:`, error);
-      throw error;
-    }
-  },
-  
-  // Registrar resultado de un partido
-  registrarResultado: async (id, resultado) => {
-    try {
-      const response = await axios.patch(`${API_URL}/partidos/${id}/resultado`, resultado);
-      return response;
-    } catch (error) {
-      console.error(`Error al registrar resultado del partido con ID ${id}:`, error);
-      throw error;
-    }
-  },
-  
-  // Eliminar un partido
-  deletePartido: async (id) => {
-    try {
-      const response = await axios.delete(`${API_URL}/partidos/${id}`);
-      return response;
-    } catch (error) {
-      console.error(`Error al eliminar partido con ID ${id}:`, error);
-      throw error;
-    }
-  },
-  
-  // Obtener estadísticas de partidos por equipo
-  getEstadisticasPorEquipo: async (equipoId) => {
-    try {
-      const response = await axios.get(`${API_URL}/partidos/estadisticas/equipo/${equipoId}`);
-      return response;
-    } catch (error) {
-      console.error(`Error al obtener estadísticas del equipo ${equipoId}:`, error);
-      throw error;
-    }
-  },
-  
-  // Obtener partidos por rango de fechas
-  getPartidosPorFechas: async (fechaInicio, fechaFin) => {
-    try {
-      const response = await axios.get(`${API_URL}/partidos`, { 
-        params: { fechaInicio, fechaFin }
-      });
-      return response;
-    } catch (error) {
-      console.error('Error al obtener partidos por fechas:', error);
-      throw error;
-    }
-  },
-  
-  // Obtener partidos por equipo
-  getPartidosPorEquipo: async (equipoId) => {
-    try {
-      const response = await axios.get(`${API_URL}/partidos`, { 
-        params: { equipo: equipoId }
-      });
-      return response;
-    } catch (error) {
-      console.error(`Error al obtener partidos del equipo ${equipoId}:`, error);
-      throw error;
-    }
-  },
-  
-  // Obtener partidos jugados o pendientes
-  getPartidosPorEstado: async (jugado) => {
-    try {
-      const response = await axios.get(`${API_URL}/partidos`, { 
-        params: { jugado }
-      });
-      return response;
-    } catch (error) {
-      console.error(`Error al obtener partidos por estado jugado=${jugado}:`, error);
-      throw error;
-    }
-  }
-};
+  getPartidos: async (params = {}) => getMatches(),
+  getPartidoById: async (id) => (await getMatches()).find(p => p.id === id) || null,
+  createPartido: async (data) => data,
+  updatePartido: async (id, data) => data,
+  registrarResultado: async (id, resultado) => ({ id, ...resultado }),
+  deletePartido: async (id) => ({ id }),
+  getEstadisticasPorEquipo: async (equipoId) => [],
+  getPartidosPorFechas: async (fechaInicio, fechaFin) => (await getMatches()).filter(p => {
+    const fecha = new Date(p.fecha)
+    return fecha >= fechaInicio && fecha <= fechaFin
+  }),
+  getPartidosPorEquipo: async (equipoId) => (await getMatches()).filter(p => p.equipo === equipoId),
+  getPartidosPorEstado: async (jugado) => (await getMatches()).filter(p => p.jugado === jugado)
+}

--- a/src/lib/api/services.js
+++ b/src/lib/api/services.js
@@ -1,438 +1,51 @@
-import axios from 'axios';
+import { getTeams, getPlayers, getPlayerById, getAttendance } from '@/lib/data-service'
 
-// URL base de la API
-const API_URL = 'https://agus-back.onrender.com/api';
-
-// Configuración por defecto para axios
-axios.defaults.headers.common['Content-Type'] = 'application/json';
-
-// Servicios para equipos
 export const equiposService = {
-  // Obtener todos los equipos
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/equipos`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener equipos:', error);
-      throw error;
-    }
-  },
+  getAll: async () => getTeams(),
+  getById: async (id) => (await getTeams()).find(e => e.id === id),
+  getByTemporada: async (temporadaId) => (await getTeams()).filter(e => e.temporadaId === temporadaId)
+}
 
-  // Obtener un equipo por ID
-  getById: async (id) => {
-    try {
-      const response = await axios.get(`${API_URL}/equipos/${id}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener equipo con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Obtener equipos por temporada
-  getByTemporada: async (temporadaId) => {
-    try {
-      const response = await axios.get(`${API_URL}/equipos/temporada/${temporadaId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener equipos de la temporada ${temporadaId}:`, error);
-      throw error;
-    }
-  },
-
-  // Crear un nuevo equipo
-  create: async (equipoData) => {
-    try {
-      const response = await axios.post(`${API_URL}/equipos`, equipoData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al crear equipo:', error);
-      throw error;
-    }
-  },
-
-  // Actualizar un equipo existente
-  update: async (id, equipoData) => {
-    try {
-      const response = await axios.put(`${API_URL}/equipos/${id}`, equipoData);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar equipo con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Eliminar un equipo
-  delete: async (id) => {
-    try {
-      const response = await axios.delete(`${API_URL}/equipos/${id}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al eliminar equipo con ID ${id}:`, error);
-      throw error;
-    }
-  }
-};
-
-// Servicios para jugadores
 export const jugadoresService = {
-  // Obtener todos los jugadores
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/jugadores`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener jugadores:', error);
-      throw error;
-    }
-  },
+  getAll: async () => getPlayers(),
+  getById: async (id) => getPlayerById(id),
+  getByEquipo: async (equipoId) => getPlayers(equipoId)
+}
 
-  // Obtener un jugador por ID
-  getById: async (id) => {
-    try {
-      const response = await axios.get(`${API_URL}/jugadores/${id}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener jugador con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Obtener jugadores por equipo
-  getByEquipo: async (equipoId) => {
-    try {
-      const response = await axios.get(`${API_URL}/jugadores/equipo/${equipoId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener jugadores del equipo ${equipoId}:`, error);
-      throw error;
-    }
-  },
-
-  // Crear un nuevo jugador
-  create: async (jugadorData) => {
-    try {
-      const response = await axios.post(`${API_URL}/jugadores`, jugadorData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al crear jugador:', error);
-      throw error;
-    }
-  },
-
-  // Actualizar un jugador existente
-  update: async (id, jugadorData) => {
-    try {
-      const response = await axios.put(`${API_URL}/jugadores/${id}`, jugadorData);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar jugador con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Eliminar un jugador
-  delete: async (id) => {
-    try {
-      const response = await axios.delete(`${API_URL}/jugadores/${id}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al eliminar jugador con ID ${id}:`, error);
-      throw error;
-    }
-  }
-};
-
-// Servicios para asistencias
 export const asistenciasService = {
-  // Obtener todas las asistencias
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/asistencias`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener asistencias:', error);
-      throw error;
-    }
-  },
+  getAll: async () => getAttendance(),
+  getByEquipo: async (equipoId) => getAttendance({ equipoId }),
+  getByJugador: async (jugadorId) => getAttendance({ jugadorId }),
+  registrar: async (data) => data,
+  update: async (id, data) => data
+}
 
-  // Obtener asistencias por equipo
-  getByEquipo: async (equipoId) => {
-    try {
-      const response = await axios.get(`${API_URL}/asistencias/equipo/${equipoId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener asistencias del equipo ${equipoId}:`, error);
-      throw error;
-    }
-  },
-
-  // Obtener asistencias por jugador
-  getByJugador: async (jugadorId) => {
-    try {
-      const response = await axios.get(`${API_URL}/asistencias/jugador/${jugadorId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener asistencias del jugador ${jugadorId}:`, error);
-      throw error;
-    }
-  },
-
-  // Registrar asistencias para un entrenamiento
-  registrar: async (asistenciasData) => {
-    try {
-      const response = await axios.post(`${API_URL}/asistencias`, asistenciasData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al registrar asistencias:', error);
-      throw error;
-    }
-  },
-
-  // Actualizar asistencia
-  update: async (id, asistenciaData) => {
-    try {
-      const response = await axios.put(`${API_URL}/asistencias/${id}`, asistenciaData);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar asistencia con ID ${id}:`, error);
-      throw error;
-    }
-  }
-};
-
-// Servicios para valoraciones
 export const valoracionesService = {
-  // Obtener todas las valoraciones
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/valoraciones`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener valoraciones:', error);
-      throw error;
-    }
-  },
+  getAll: async () => [],
+  getByJugador: async () => [],
+  getByEquipo: async () => [],
+  create: async (data) => data,
+  update: async (id, data) => data
+}
 
-  // Obtener valoraciones por jugador
-  getByJugador: async (jugadorId) => {
-    try {
-      const response = await axios.get(`${API_URL}/valoraciones/jugador/${jugadorId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener valoraciones del jugador ${jugadorId}:`, error);
-      throw error;
-    }
-  },
-
-  // Obtener valoraciones por equipo
-  getByEquipo: async (equipoId) => {
-    try {
-      const response = await axios.get(`${API_URL}/valoraciones/equipo/${equipoId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener valoraciones del equipo ${equipoId}:`, error);
-      throw error;
-    }
-  },
-
-  // Crear una nueva valoración
-  create: async (valoracionData) => {
-    try {
-      const response = await axios.post(`${API_URL}/valoraciones`, valoracionData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al crear valoración:', error);
-      throw error;
-    }
-  },
-
-  // Actualizar una valoración existente
-  update: async (id, valoracionData) => {
-    try {
-      const response = await axios.put(`${API_URL}/valoraciones/${id}`, valoracionData);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar valoración con ID ${id}:`, error);
-      throw error;
-    }
-  }
-};
-
-// Servicios para scouting
 export const scoutingService = {
-  // Obtener todos los registros de scouting
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/scouting`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener registros de scouting:', error);
-      throw error;
-    }
-  },
+  getAll: async () => [],
+  getById: async () => null,
+  buscarPorNombre: async () => [],
+  create: async (data) => data,
+  update: async (id, data) => data
+}
 
-  // Obtener un registro de scouting por ID
-  getById: async (id) => {
-    try {
-      const response = await axios.get(`${API_URL}/scouting/${id}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener registro de scouting con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Buscar jugadores scouteados por nombre
-  buscarPorNombre: async (nombre) => {
-    try {
-      const response = await axios.get(`${API_URL}/scouting/buscar?nombre=${nombre}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al buscar jugadores scouteados con nombre ${nombre}:`, error);
-      throw error;
-    }
-  },
-
-  // Crear un nuevo registro de scouting
-  create: async (scoutingData) => {
-    try {
-      const response = await axios.post(`${API_URL}/scouting`, scoutingData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al crear registro de scouting:', error);
-      throw error;
-    }
-  },
-
-  // Actualizar un registro de scouting existente
-  update: async (id, scoutingData) => {
-    try {
-      const response = await axios.put(`${API_URL}/scouting/${id}`, scoutingData);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar registro de scouting con ID ${id}:`, error);
-      throw error;
-    }
-  }
-};
-
-// Servicios para objetivos
 export const objetivosService = {
-  // Obtener todos los objetivos
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/objetivos`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener objetivos:', error);
-      throw error;
-    }
-  },
+  getAll: async () => [],
+  getByEquipo: async () => [],
+  create: async (data) => data,
+  update: async (id, data) => data,
+  actualizarProgreso: async (id, progreso) => ({ id, progreso })
+}
 
-  // Obtener objetivos por equipo
-  getByEquipo: async (equipoId) => {
-    try {
-      const response = await axios.get(`${API_URL}/objetivos/equipo/${equipoId}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener objetivos del equipo ${equipoId}:`, error);
-      throw error;
-    }
-  },
-
-  // Crear un nuevo objetivo
-  create: async (objetivoData) => {
-    try {
-      const response = await axios.post(`${API_URL}/objetivos`, objetivoData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al crear objetivo:', error);
-      throw error;
-    }
-  },
-
-  // Actualizar un objetivo existente
-  update: async (id, objetivoData) => {
-    try {
-      const response = await axios.put(`${API_URL}/objetivos/${id}`, objetivoData);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar objetivo con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Actualizar el progreso de un objetivo
-  actualizarProgreso: async (id, progreso) => {
-    try {
-      const response = await axios.patch(`${API_URL}/objetivos/${id}/progreso`, { progreso });
-      return response.data;
-    } catch (error) {
-      console.error(`Error al actualizar progreso del objetivo con ID ${id}:`, error);
-      throw error;
-    }
-  }
-};
-
-// Servicios para temporadas
 export const temporadasService = {
-  // Obtener todas las temporadas
-  getAll: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/temporadas`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener temporadas:', error);
-      throw error;
-    }
-  },
-
-  // Obtener temporada actual
-  getActual: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/temporadas/actual`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al obtener temporada actual:', error);
-      throw error;
-    }
-  },
-
-  // Crear una nueva temporada
-  create: async (temporadaData) => {
-    try {
-      const response = await axios.post(`${API_URL}/temporadas`, temporadaData);
-      return response.data;
-    } catch (error) {
-      console.error('Error al crear temporada:', error);
-      throw error;
-    }
-  }
-};
-
-// Servicio para verificar el estado de la API
-export const apiService = {
-  checkStatus: async () => {
-    try {
-      const response = await axios.get(`${API_URL}/status`);
-      return response.data;
-    } catch (error) {
-      console.error('Error al verificar estado de la API:', error);
-      throw error;
-    }
-  }
-};
-
-// Exportar todos los servicios
-export default {
-  equipos: equiposService,
-  jugadores: jugadoresService,
-  asistencias: asistenciasService,
-  valoraciones: valoracionesService,
-  scouting: scoutingService,
-  objetivos: objetivosService,
-  temporadas: temporadasService,
-  api: apiService
-};
+  getAll: async () => [],
+  getActual: async () => null,
+  create: async (data) => data
+}

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,9 +1,0 @@
-// src/lib/api/client.ts
-import axios from "axios"
-
-export const apiClient = axios.create({
-  baseURL: "https://agus-back.onrender.com/api", // esto ya lo tienes bien
-  headers: {
-    "Content-Type": "application/json",
-  },
-})

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -1,0 +1,73 @@
+import data from '@/data/cadete-b.json'
+
+export interface Player {
+  id: string
+  nombre: string
+  apellidos: string
+  posicion: string
+  dorsal: number
+  asistencia?: string
+  equipoId?: string
+}
+
+export interface AttendanceRecord {
+  id: string
+  equipoId: string
+  fecha: string
+  tipo: string
+  asistencia?: string
+  jugadores: {
+    id: string
+    nombre?: string
+    asistio: boolean
+    motivo: string | null
+  }[]
+}
+
+interface DataFile {
+  teams?: { id: string; nombre: string; categoria?: string }[]
+  players: Player[]
+  attendance: AttendanceRecord[]
+  matches?: any[]
+}
+
+const db = data as DataFile
+
+export function getTeams() {
+  return db.teams || []
+}
+
+export function getPlayers(equipoId?: string) {
+  return equipoId ? db.players.filter(p => p.equipoId === equipoId) : db.players
+}
+
+export function getPlayerById(id: string) {
+  return db.players.find(p => p.id === id)
+}
+
+export function getAttendance(options: { equipoId?: string; jugadorId?: string } = {}) {
+  let records = db.attendance
+  if (options.equipoId) {
+    records = records.filter(r => r.equipoId === options.equipoId)
+  }
+  if (options.jugadorId) {
+    return records
+      .map(r => {
+        const jugador = r.jugadores.find(j => j.id === options.jugadorId)
+        if (!jugador) return null
+        return {
+          id: r.id,
+          fecha: r.fecha,
+          tipo: r.tipo,
+          asistio: jugador.asistio,
+          motivo: jugador.motivo,
+        }
+      })
+      .filter((r): r is { id: string; fecha: string; tipo: string; asistio: boolean; motivo: string | null } => r !== null)
+  }
+  return records
+}
+
+export function getMatches() {
+  return db.matches || []
+}


### PR DESCRIPTION
## Summary
- add data service parsing local `cadete-b` dataset
- rewrite API context and services to read local data
- remove axios usage and provider status checker

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(failed: interactive configuration required)*

------
https://chatgpt.com/codex/tasks/task_e_68ad99da88e08320ad68d97311229276