### PR TITLE
feat: add cadete b updater script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Club San Agustín Frontend
+
+## Actualizar datos de Cadete B
+
+Este proyecto incluye un script para modificar el archivo `public/cadete-b.json`.
+
+```bash
+npx ts-node scripts/update-cadete-b.ts --password <CONTRASEÑA> --data '{"coach":"Nuevo entrenador"}'
+```
+
+La contraseña por defecto es `secret` y puede cambiarse estableciendo la variable de entorno `CADETE_B_PASSWORD`.

--- a/public/cadete-b.json
+++ b/public/cadete-b.json
@@ -1,0 +1,4 @@
+{
+  "team": "Cadete B",
+  "players": []
+}

--- a/scripts/update-cadete-b.ts
+++ b/scripts/update-cadete-b.ts
@@ -1,0 +1,56 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+import { promises as fs } from 'fs';
+import path from 'path';
+
+interface Args {
+  [key: string]: string;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const result: Args = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      const key = args[i].slice(2);
+      const value = args[i + 1];
+      result[key] = value;
+      i++;
+    }
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs();
+  const expectedPassword = process.env.CADETE_B_PASSWORD || 'secret';
+
+  if (args.password !== expectedPassword) {
+    console.error('Incorrect password.');
+    process.exit(1);
+  }
+
+  if (!args.data) {
+    console.error('Missing --data argument.');
+    process.exit(1);
+  }
+
+  let newData;
+  try {
+    newData = JSON.parse(args.data);
+  } catch (err) {
+    console.error('Invalid JSON for --data.');
+    process.exit(1);
+  }
+
+  const filePath = path.join(process.cwd(), 'public', 'cadete-b.json');
+  const currentRaw = await fs.readFile(filePath, 'utf8');
+  const current = JSON.parse(currentRaw);
+
+  const updated = { ...current, ...newData };
+
+  await fs.writeFile(filePath, JSON.stringify(updated, null, 2));
+  console.log('cadete-b.json updated successfully.');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add sample cadete-b.json data file
- add protected script to update cadete-b.json
- document script usage in README

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ada4972cc08320ba3e3b4af1a9fe05