### PR TITLE
feat: consume services via API routes

### DIFF
--- a/src/app/api/equipos/route.ts
+++ b/src/app/api/equipos/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { equiposService } from '@/lib/api/services'
+import { revalidatePath } from 'next/cache'
+
+export async function GET() {
+  try {
+    const equipos = await equiposService.getAll()
+    return NextResponse.json(equipos)
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Error al obtener equipos' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+    const nuevo = await equiposService.create(body)
+    revalidatePath('/dashboard/equipos')
+    return NextResponse.json(nuevo, { status: 201 })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Error al crear equipo' }, { status: 500 })
+  }
+}

--- a/src/app/api/jugadores/route.ts
+++ b/src/app/api/jugadores/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { jugadoresService } from '@/lib/api/services'
+import { revalidatePath } from 'next/cache'
+
+export async function GET() {
+  try {
+    const jugadores = await jugadoresService.getAll()
+    return NextResponse.json(jugadores)
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Error al obtener jugadores' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+    const nuevo = await jugadoresService.create(body)
+    revalidatePath('/dashboard/jugadores')
+    return NextResponse.json(nuevo, { status: 201 })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Error al crear jugador' }, { status: 500 })
+  }
+}

--- a/src/app/api/temporadas/route.ts
+++ b/src/app/api/temporadas/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { temporadasService } from '@/lib/api/services'
+import { revalidatePath } from 'next/cache'
+
+export async function GET() {
+  try {
+    const temporadas = await temporadasService.getAll()
+    return NextResponse.json(temporadas)
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Error al obtener temporadas' }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+    const nueva = await temporadasService.create(body)
+    revalidatePath('/dashboard/horarios')
+    return NextResponse.json(nueva, { status: 201 })
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Error al crear temporada' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/equipos/page.tsx
+++ b/src/app/dashboard/equipos/page.tsx
@@ -9,54 +9,42 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from "@/components/ui/input"
 import { SectionCards } from "@/components/section-cards"
 
-// Datos de ejemplo - en producción vendrían de la API
-const teams = [
-  {
-    id: "1",
-    name: "Alevín A",
-    category: "1ª Alevín",
-    players: 15,
-    coach: "Carlos Martínez",
-    image: null
-  },
-  {
-    id: "2",
-    name: "Benjamín B",
-    category: "2ª Benjamín",
-    players: 14,
-    coach: "Laura Sánchez",
-    image: null
-  },
-  {
-    id: "3",
-    name: "Infantil A",
-    category: "1ª Infantil",
-    players: 18,
-    coach: "Miguel López",
-    image: null
-  },
-  {
-    id: "4",
-    name: "Cadete B",
-    category: "2ª Cadete",
-    players: 16,
-    coach: "Ana García",
-    image: null
-  },
-  {
-    id: "5",
-    name: "Juvenil A",
-    category: "1ª Juvenil",
-    players: 18,
-    coach: "Pedro Rodríguez",
-    image: null
-  },
-]
+interface Team {
+  id: string
+  name: string
+  category: string
+  players: number
+  coach: string
+  image: string | null
+}
 
 export default function EquiposPage() {
   const [searchQuery, setSearchQuery] = React.useState("")
-  
-  const filteredTeams = teams.filter(team => 
+  const [teams, setTeams] = React.useState<Team[]>([])
+
+  React.useEffect(() => {
+    const fetchEquipos = async () => {
+      try {
+        const res = await fetch('/api/equipos')
+        if (!res.ok) throw new Error('Error al obtener equipos')
+        const data = await res.json()
+        const mapped: Team[] = data.map((equipo: any) => ({
+          id: equipo._id,
+          name: equipo.nombre,
+          category: equipo.categoria,
+          players: equipo.jugadores?.length ?? equipo.jugadores ?? 0,
+          coach: equipo.entrenador || '',
+          image: null,
+        }))
+        setTeams(mapped)
+      } catch (error) {
+        console.error('Error al cargar equipos:', error)
+      }
+    }
+    fetchEquipos()
+  }, [])
+
+  const filteredTeams = teams.filter(team =>
     team.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
     team.category.toLowerCase().includes(searchQuery.toLowerCase()) ||
     team.coach.toLowerCase().includes(searchQuery.toLowerCase())

--- a/src/app/dashboard/horarios/editar/[id]/page.tsx
+++ b/src/app/dashboard/horarios/editar/[id]/page.tsx
@@ -22,7 +22,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
-import { equiposService, temporadasService } from "@/lib/api/services"
+// Los equipos y temporadas se obtienen desde la API del proyecto
 import { partidosService } from "@/lib/api/partidos"
 import { PartidoFormData, Partido } from "@/types/horarios"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -83,20 +83,28 @@ export default function EditarPartidoPage() {
         // Cargar partido
         const partidoResponse = await partidosService.getPartidoById(params.id as string)
         setPartido(partidoResponse.data)
-        
+
         // Cargar equipos
-        const equiposResponse = await equiposService.getAll()
-        setEquipos(equiposResponse.map((equipo: { _id: any; nombre: any }) => ({
-          value: equipo._id,
-          label: equipo.nombre
-        })))
-        
+        const equiposRes = await fetch('/api/equipos')
+        if (!equiposRes.ok) throw new Error('Error al obtener equipos')
+        const equiposData = await equiposRes.json()
+        setEquipos(
+          equiposData.map((equipo: { _id: any; nombre: any }) => ({
+            value: equipo._id,
+            label: equipo.nombre
+          }))
+        )
+
         // Cargar temporadas
-        const temporadasResponse = await temporadasService.getAll()
-        setTemporadas(temporadasResponse.map((temporada: { _id: any; nombre: any }) => ({
-          value: temporada._id,
-          label: temporada.nombre
-        })))
+        const temporadasRes = await fetch('/api/temporadas')
+        if (!temporadasRes.ok) throw new Error('Error al obtener temporadas')
+        const temporadasData = await temporadasRes.json()
+        setTemporadas(
+          temporadasData.map((temporada: { _id: any; nombre: any }) => ({
+            value: temporada._id,
+            label: temporada.nombre
+          }))
+        )
         
         // Establecer valores del formulario
         const partidoData = partidoResponse.data

--- a/src/app/dashboard/horarios/nuevo/page.tsx
+++ b/src/app/dashboard/horarios/nuevo/page.tsx
@@ -23,7 +23,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
-import { equiposService, temporadasService } from "@/lib/api/services"
+// Los datos se obtienen mediante llamadas a las rutas de la API del proyecto
 import { partidosService } from "@/lib/api/partidos"
 import { useEffect } from "react"
 import { PartidoFormData } from "@/types/horarios"
@@ -81,21 +81,29 @@ export default function NuevoPartidoPage() {
         setLoading(true)
         
         // Cargar equipos
-        const equiposResponse = await equiposService.getAll()
-        setEquipos(equiposResponse.map((equipo: { _id: any; nombre: any }) => ({
-          value: equipo._id,
-          label: equipo.nombre
-        })))
-        
+        const equiposRes = await fetch('/api/equipos')
+        if (!equiposRes.ok) throw new Error('Error al obtener equipos')
+        const equiposData = await equiposRes.json()
+        setEquipos(
+          equiposData.map((equipo: { _id: any; nombre: any }) => ({
+            value: equipo._id,
+            label: equipo.nombre
+          }))
+        )
+
         // Cargar temporadas
-        const temporadasResponse = await temporadasService.getAll()
-        setTemporadas(temporadasResponse.map((temporada: { _id: any; nombre: any }) => ({
-          value: temporada._id,
-          label: temporada.nombre
-        })))
-        
+        const temporadasRes = await fetch('/api/temporadas')
+        if (!temporadasRes.ok) throw new Error('Error al obtener temporadas')
+        const temporadasData = await temporadasRes.json()
+        setTemporadas(
+          temporadasData.map((temporada: { _id: any; nombre: any }) => ({
+            value: temporada._id,
+            label: temporada.nombre
+          }))
+        )
+
         // Establecer temporada activa por defecto
-        const temporadaActiva = temporadasResponse.find((t: { activa: any }) => t.activa)
+        const temporadaActiva = temporadasData.find((t: { activa: any }) => t.activa)
         if (temporadaActiva) {
           form.setValue("temporada", temporadaActiva._id)
         }

--- a/src/app/dashboard/horarios/page.tsx
+++ b/src/app/dashboard/horarios/page.tsx
@@ -9,7 +9,7 @@ import { PartidosList } from "@/components/horarios/partidos-list"
 import { ResultadosList } from "@/components/horarios/resultados-list"
 import { EstadisticasView } from "@/components/horarios/estadisticas-view"
 import { CustomSelect } from "@/components/ui/custom-select"
-import { equiposService } from "@/lib/api/services"
+// Los equipos se obtienen desde la API del proyecto
 import { addDays } from "date-fns"
 import Link from "next/link"
 import { Plus } from "lucide-react"
@@ -34,11 +34,15 @@ export default function HorariosPage() {
     const fetchEquipos = async () => {
       try {
         setLoading(true)
-        const response = await equiposService.getAll()
-        setEquipos(response.map((equipo: { _id: string; nombre: string }) => ({
-          value: equipo._id,
-          label: equipo.nombre,
-        })))
+        const res = await fetch('/api/equipos')
+        if (!res.ok) throw new Error('Error al obtener equipos')
+        const data = await res.json()
+        setEquipos(
+          data.map((equipo: { _id: string; nombre: string }) => ({
+            value: equipo._id,
+            label: equipo.nombre,
+          }))
+        )
       } catch (error) {
         console.error("Error al cargar equipos:", error)
       } finally {

--- a/src/app/dashboard/jugadores/page.tsx
+++ b/src/app/dashboard/jugadores/page.tsx
@@ -9,98 +9,25 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 
-// Datos de ejemplo - en producción vendrían de la API
-const jugadores = [
-  {
-    id: "1",
-    nombre: "Juan",
-    apellidos: "García López",
-    posicion: "Delantero",
-    dorsal: 9,
-    equipo: "Alevín A",
-    categoria: "1ª Alevín",
-    fechaNacimiento: "2014-05-12",
-    asistencia: "95%",
-    valoracionMedia: 4.2
-  },
-  {
-    id: "2",
-    nombre: "Miguel",
-    apellidos: "Fernández Ruiz",
-    posicion: "Centrocampista",
-    dorsal: 8,
-    equipo: "Alevín A",
-    categoria: "1ª Alevín",
-    fechaNacimiento: "2014-03-22",
-    asistencia: "90%",
-    valoracionMedia: 3.8
-  },
-  {
-    id: "3",
-    nombre: "Carlos",
-    apellidos: "Martínez Sanz",
-    posicion: "Defensa",
-    dorsal: 4,
-    equipo: "Benjamín B",
-    categoria: "2ª Benjamín",
-    fechaNacimiento: "2015-07-15",
-    asistencia: "85%",
-    valoracionMedia: 3.5
-  },
-  {
-    id: "4",
-    nombre: "David",
-    apellidos: "López Gómez",
-    posicion: "Portero",
-    dorsal: 1,
-    equipo: "Infantil A",
-    categoria: "1ª Infantil",
-    fechaNacimiento: "2012-11-30",
-    asistencia: "100%",
-    valoracionMedia: 4.5
-  },
-  {
-    id: "5",
-    nombre: "Javier",
-    apellidos: "Sánchez Pérez",
-    posicion: "Defensa",
-    dorsal: 2,
-    equipo: "Cadete B",
-    categoria: "2ª Cadete",
-    fechaNacimiento: "2010-02-18",
-    asistencia: "80%",
-    valoracionMedia: 3.7
-  },
-  {
-    id: "6",
-    nombre: "Alejandro",
-    apellidos: "González Díaz",
-    posicion: "Centrocampista",
-    dorsal: 6,
-    equipo: "Juvenil A",
-    categoria: "1ª Juvenil",
-    fechaNacimiento: "2008-09-05",
-    asistencia: "85%",
-    valoracionMedia: 4.0
-  },
-  {
-    id: "7",
-    nombre: "Daniel",
-    apellidos: "Pérez Martín",
-    posicion: "Delantero",
-    dorsal: 11,
-    equipo: "Juvenil A",
-    categoria: "1ª Juvenil",
-    fechaNacimiento: "2008-12-20",
-    asistencia: "90%",
-    valoracionMedia: 4.3
-  },
-]
-
 export default function JugadoresPage() {
   const [searchQuery, setSearchQuery] = React.useState("")
-  
-  const filteredJugadores = jugadores.filter(jugador => 
+  const [jugadores, setJugadores] = React.useState<any[]>([])
+
+  React.useEffect(() => {
+    const fetchJugadores = async () => {
+      try {
+        const res = await fetch('/api/jugadores')
+        if (!res.ok) throw new Error('Error al obtener jugadores')
+        const data = await res.json()
+        setJugadores(data)
+      } catch (error) {
+        console.error('Error al cargar jugadores:', error)
+      }
+    }
+    fetchJugadores()
+  }, [])
+
+  const filteredJugadores = jugadores.filter((jugador) =>
     jugador.nombre.toLowerCase().includes(searchQuery.toLowerCase()) ||
     jugador.apellidos.toLowerCase().includes(searchQuery.toLowerCase()) ||
     jugador.equipo.toLowerCase().includes(searchQuery.toLowerCase()) ||

--- a/src/components/team-selector.tsx
+++ b/src/components/team-selector.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button"
 
-import { equiposService } from "@/lib/api/services" // 👈 asegúrate de que este import esté correcto
+// Los datos de los equipos ahora se obtienen mediante fetch a la ruta API
 
 interface Team {
   id: string
@@ -32,9 +32,11 @@ export function TeamSelector() {
   React.useEffect(() => {
     const fetchEquipos = async () => {
       try {
-        const response = await equiposService.getAll()
+        const res = await fetch('/api/equipos')
+        if (!res.ok) throw new Error('Error al obtener equipos')
+        const data = await res.json()
 
-        const mapped: Team[] = response.map((equipo: any) => ({
+        const mapped: Team[] = data.map((equipo: any) => ({
           id: equipo._id,
           name: equipo.nombre,
           category: equipo.categoria,


### PR DESCRIPTION
## Summary
- add Next.js API routes for equipos, jugadores and temporadas
- fetch data from new API routes in dashboard and selectors
- replace mock lists with dynamic service data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aedf03422c83209b42c2ec33513da7