### PR TITLE
feat: add scouting service and API integration

### DIFF
--- a/src/app/api/scouting/route.ts
+++ b/src/app/api/scouting/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const dataFile = path.join(process.cwd(), 'src', 'data', 'scouting.json')
+
+async function readData() {
+  try {
+    const data = await fs.readFile(dataFile, 'utf-8')
+    return JSON.parse(data)
+  } catch {
+    return []
+  }
+}
+
+async function writeData(data: any) {
+  await fs.writeFile(dataFile, JSON.stringify(data, null, 2))
+}
+
+export async function GET() {
+  const data = await readData()
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  const newItem = await request.json()
+  const data = await readData()
+  const item = { id: Date.now().toString(), ...newItem }
+  data.push(item)
+  await writeData(data)
+  return NextResponse.json(item, { status: 201 })
+}
+
+export async function PUT(request: Request) {
+  const updated = await request.json()
+  const data = await readData()
+  const index = data.findIndex((item: any) => item.id === updated.id)
+  if (index === -1) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 })
+  }
+  data[index] = { ...data[index], ...updated }
+  await writeData(data)
+  return NextResponse.json(data[index])
+}
+
+export async function DELETE(request: Request) {
+  const { id } = await request.json()
+  let data = await readData()
+  const index = data.findIndex((item: any) => item.id === id)
+  if (index === -1) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 })
+  }
+  const removed = data[index]
+  data = data.filter((item: any) => item.id !== id)
+  await writeData(data)
+  return NextResponse.json(removed)
+}

--- a/src/app/dashboard/scouting/page.tsx
+++ b/src/app/dashboard/scouting/page.tsx
@@ -18,143 +18,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command"
 import { cn } from "@/lib/utils"
 import { Separator } from "@/components/ui/separator"
+import { scoutingService } from "@/lib/api/services"
 
-// Datos de ejemplo - en producción vendrían de la API
-const jugadoresScouteados = [
-  { 
-    id: "1", 
-    nombre: "Alejandro", 
-    apellido: "Martínez", 
-    equipo: "CD Leganés", 
-    añoNacimiento: 2012,
-    demarcacion: "Centrocampista",
-    lateralidad: "Derecha",
-    altura: "Alto",
-    complexion: "Atlético",
-    capacidadFisica: 4,
-    capacidadTecnica: 5,
-    capacidadTactica: 4,
-    capacidadDefensiva: 3,
-    mental: 4,
-    portero: 0,
-    propuesta: "FICHAR",
-    dificultad: "POSIBLE",
-    observaciones: "Excelente visión de juego y técnica. Destaca por su capacidad de pase y control.",
-    fechaScouting: "2025-03-15",
-    entrenador: "Carlos Pérez",
-    equipoCDSA: "Infantil A",
-    categoria: "1ª Infantil",
-    historial: [
-      {
-        fechaScouting: "2024-05-20",
-        equipo: "EF Alcobendas",
-        capacidadFisica: 3,
-        capacidadTecnica: 4,
-        capacidadTactica: 3,
-        capacidadDefensiva: 3,
-        mental: 3,
-        propuesta: "SEGUIMIENTO",
-        observaciones: "Jugador con potencial pero necesita mejorar físicamente."
-      }
-    ]
-  },
-  { 
-    id: "2", 
-    nombre: "Daniel", 
-    apellido: "García", 
-    equipo: "Rayo Vallecano", 
-    añoNacimiento: 2013,
-    demarcacion: "Delantero",
-    lateralidad: "Izquierda",
-    altura: "Altura media",
-    complexion: "Atlético",
-    capacidadFisica: 5,
-    capacidadTecnica: 4,
-    capacidadTactica: 3,
-    capacidadDefensiva: 2,
-    mental: 5,
-    portero: 0,
-    propuesta: "FICHAR",
-    dificultad: "COMPLICADO",
-    observaciones: "Delantero muy rápido y con gran definición. Destaca por su velocidad y capacidad goleadora.",
-    fechaScouting: "2025-02-28",
-    entrenador: "Miguel López",
-    equipoCDSA: "Alevín A",
-    categoria: "1ª Alevín"
-  },
-  { 
-    id: "3", 
-    nombre: "Pablo", 
-    apellido: "Rodríguez", 
-    equipo: "Atlético de Madrid", 
-    añoNacimiento: 2011,
-    demarcacion: "Defensa",
-    lateralidad: "Derecha",
-    altura: "Alto",
-    complexion: "Fuerte",
-    capacidadFisica: 4,
-    capacidadTecnica: 3,
-    capacidadTactica: 4,
-    capacidadDefensiva: 5,
-    mental: 4,
-    portero: 0,
-    propuesta: "NO FICHAR",
-    dificultad: "IMPOSIBLE",
-    observaciones: "Defensa central con gran capacidad física y buen juego aéreo. Pertenece a la cantera del Atlético.",
-    fechaScouting: "2025-01-15",
-    entrenador: "Laura Sánchez",
-    equipoCDSA: "Cadete B",
-    categoria: "2ª Cadete"
-  },
-  { 
-    id: "4", 
-    nombre: "Mario", 
-    apellido: "Fernández", 
-    equipo: "Getafe CF", 
-    añoNacimiento: 2014,
-    demarcacion: "Portero",
-    lateralidad: "Derecha",
-    altura: "Alto",
-    complexion: "Atlético",
-    capacidadFisica: 3,
-    capacidadTecnica: 4,
-    capacidadTactica: 4,
-    capacidadDefensiva: 3,
-    mental: 5,
-    portero: 5,
-    propuesta: "FICHAR",
-    dificultad: "POSIBLE",
-    observaciones: "Portero con grandes reflejos y buen juego con los pies. Destaca por su colocación y seguridad.",
-    fechaScouting: "2025-03-05",
-    entrenador: "Pedro Martín",
-    equipoCDSA: "Benjamín A",
-    categoria: "1ª Benjamín"
-  },
-  { 
-    id: "5", 
-    nombre: "Javier", 
-    apellido: "López", 
-    equipo: "AD Alcorcón", 
-    añoNacimiento: 2012,
-    demarcacion: "Centrocampista",
-    lateralidad: "Ambas",
-    altura: "Altura media",
-    complexion: "Delgado",
-    capacidadFisica: 3,
-    capacidadTecnica: 5,
-    capacidadTactica: 5,
-    capacidadDefensiva: 3,
-    mental: 4,
-    portero: 0,
-    propuesta: "FICHAR",
-    dificultad: "POSIBLE",
-    observaciones: "Centrocampista muy técnico y con gran visión de juego. Ambidiestro y con gran capacidad de pase.",
-    fechaScouting: "2025-02-10",
-    entrenador: "Carlos Pérez",
-    equipoCDSA: "Infantil A",
-    categoria: "1ª Infantil"
-  }
-]
 
 // Opciones para los selectores
 const demarcaciones = ["Portero", "Defensa", "Centrocampista", "Delantero"]
@@ -232,6 +97,21 @@ export default function ScoutingPage() {
   const [filtroPropuesta, setFiltroPropuesta] = React.useState("todas")
   const [filtroDemarcacion, setFiltroDemarcacion] = React.useState("todas")
   const [jugadorSeleccionado, setJugadorSeleccionado] = React.useState<string | null>(null)
+
+  const [jugadoresScouteados, setJugadoresScouteados] = React.useState<Jugador[]>([])
+
+  const fetchJugadores = async () => {
+    try {
+      const data = await scoutingService.getAll()
+      setJugadoresScouteados(data)
+    } catch (error) {
+      console.error('Error al cargar scouting:', error)
+    }
+  }
+
+  React.useEffect(() => {
+    fetchJugadores()
+  }, [])
   
   // Estado para el formulario de nuevo scouting
   const [formData, setFormData] = React.useState({
@@ -374,19 +254,30 @@ export default function ScoutingPage() {
   }
   
   // Guardar scouting
-  const handleGuardarScouting = () => {
-    // Aquí se enviarían los datos al backend
-    console.log("Guardando scouting:", formData)
-    
-    // Mostrar mensaje de éxito (en una implementación real)
-    alert(formData.actualizando 
-      ? "Valoración de scouting actualizada correctamente" 
-      : "Nuevo scouting registrado correctamente"
-    )
-    
-    // Resetear formulario y volver al listado
-    resetForm()
-    setActiveTab("listado")
+  const handleGuardarScouting = async () => {
+    const { actualizando, jugadorId, ...payload } = formData
+    try {
+      if (actualizando && jugadorId) {
+        await scoutingService.update(jugadorId, payload)
+      } else {
+        await scoutingService.create(payload)
+      }
+      resetForm()
+      setActiveTab("listado")
+      fetchJugadores()
+    } catch (error) {
+      console.error('Error al guardar scouting:', error)
+    }
+  }
+
+  const handleEliminar = async (id: string) => {
+    try {
+      await scoutingService.delete(id)
+      setJugadorSeleccionado(null)
+      fetchJugadores()
+    } catch (error) {
+      console.error('Error al eliminar scouting:', error)
+    }
   }
   
   return (
@@ -701,15 +592,12 @@ export default function ScoutingPage() {
                   </div>
                 </CardContent>
                 <CardFooter className="flex justify-end gap-2">
-                  <Button 
-                    variant="outline"
-                    onClick={() => {
-                      // Aquí se implementaría la lógica para eliminar el registro
-                      alert("Esta funcionalidad eliminaría el registro en una implementación real")
-                    }}
-                  >
-                    Eliminar
-                  </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => jugadorDetalle && handleEliminar(jugadorDetalle.id)}
+                    >
+                      Eliminar
+                    </Button>
                   <Button
                     onClick={() => {
                       // Preparar formulario con datos del jugador

--- a/src/data/scouting.json
+++ b/src/data/scouting.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "1",
+    "nombre": "Alejandro",
+    "apellido": "Martínez",
+    "equipo": "CD Leganés",
+    "añoNacimiento": 2012,
+    "demarcacion": "Centrocampista",
+    "lateralidad": "Derecha",
+    "altura": "Alto",
+    "complexion": "Atlético",
+    "capacidadFisica": 4,
+    "capacidadTecnica": 5,
+    "capacidadTactica": 4,
+    "capacidadDefensiva": 3,
+    "mental": 4,
+    "portero": 0,
+    "propuesta": "FICHAR",
+    "dificultad": "POSIBLE",
+    "observaciones": "Excelente visión de juego y técnica. Destaca por su capacidad de pase y control.",
+    "fechaScouting": "2025-03-15",
+    "entrenador": "Carlos Pérez",
+    "equipoCDSA": "Infantil A",
+    "categoria": "1ª Infantil",
+    "historial": [
+      {
+        "fechaScouting": "2024-05-20",
+        "equipo": "EF Alcobendas",
+        "capacidadFisica": 3,
+        "capacidadTecnica": 4,
+        "capacidadTactica": 3,
+        "capacidadDefensiva": 3,
+        "mental": 3,
+        "propuesta": "SEGUIMIENTO",
+        "observaciones": "Jugador con potencial pero necesita mejorar físicamente."
+      }
+    ]
+  },
+  {
+    "id": "2",
+    "nombre": "Daniel",
+    "apellido": "García",
+    "equipo": "Rayo Vallecano",
+    "añoNacimiento": 2013,
+    "demarcacion": "Delantero",
+    "lateralidad": "Izquierda",
+    "altura": "Altura media",
+    "complexion": "Atlético",
+    "capacidadFisica": 5,
+    "capacidadTecnica": 4,
+    "capacidadTactica": 3,
+    "capacidadDefensiva": 2,
+    "mental": 5,
+    "portero": 0,
+    "propuesta": "FICHAR",
+    "dificultad": "COMPLICADO",
+    "observaciones": "Delantero muy rápido y con gran definición. Destaca por su velocidad y capacidad goleadora.",
+    "fechaScouting": "2025-02-28",
+    "entrenador": "Miguel López",
+    "equipoCDSA": "Alevín A",
+    "categoria": "1ª Alevín"
+  }
+]

--- a/src/lib/api/services.js
+++ b/src/lib/api/services.js
@@ -260,12 +260,12 @@ export const valoracionesService = {
   }
 };
 
-// Servicios para scouting
+// Servicios para scouting utilizando el endpoint interno de Next.js
 export const scoutingService = {
   // Obtener todos los registros de scouting
   getAll: async () => {
     try {
-      const response = await axios.get(`${API_URL}/scouting`);
+      const response = await axios.get('/api/scouting');
       return response.data;
     } catch (error) {
       console.error('Error al obtener registros de scouting:', error);
@@ -273,32 +273,10 @@ export const scoutingService = {
     }
   },
 
-  // Obtener un registro de scouting por ID
-  getById: async (id) => {
-    try {
-      const response = await axios.get(`${API_URL}/scouting/${id}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al obtener registro de scouting con ID ${id}:`, error);
-      throw error;
-    }
-  },
-
-  // Buscar jugadores scouteados por nombre
-  buscarPorNombre: async (nombre) => {
-    try {
-      const response = await axios.get(`${API_URL}/scouting/buscar?nombre=${nombre}`);
-      return response.data;
-    } catch (error) {
-      console.error(`Error al buscar jugadores scouteados con nombre ${nombre}:`, error);
-      throw error;
-    }
-  },
-
   // Crear un nuevo registro de scouting
   create: async (scoutingData) => {
     try {
-      const response = await axios.post(`${API_URL}/scouting`, scoutingData);
+      const response = await axios.post('/api/scouting', scoutingData);
       return response.data;
     } catch (error) {
       console.error('Error al crear registro de scouting:', error);
@@ -309,10 +287,21 @@ export const scoutingService = {
   // Actualizar un registro de scouting existente
   update: async (id, scoutingData) => {
     try {
-      const response = await axios.put(`${API_URL}/scouting/${id}`, scoutingData);
+      const response = await axios.put('/api/scouting', { id, ...scoutingData });
       return response.data;
     } catch (error) {
       console.error(`Error al actualizar registro de scouting con ID ${id}:`, error);
+      throw error;
+    }
+  },
+
+  // Eliminar un registro de scouting
+  delete: async (id) => {
+    try {
+      const response = await axios.delete('/api/scouting', { data: { id } });
+      return response.data;
+    } catch (error) {
+      console.error(`Error al eliminar registro de scouting con ID ${id}:`, error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- add local scouting data file and API route
- expose scouting CRUD utilities in services layer
- load and modify scouting entries from ScoutingPage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68aedf0989908320939fd50dcd0ce826