### PR TITLE
Fetch team players dynamically and revalidate roster

### DIFF
--- a/src/lib/actions/jugadores.ts
+++ b/src/lib/actions/jugadores.ts
@@ -1,0 +1,17 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { jugadoresService } from "@/lib/api/services"
+
+export async function createJugador(data: any) {
+  const jugador = await jugadoresService.create(data)
+  revalidatePath("/dashboard/jugadores")
+  return jugador
+}
+
+export async function updateJugador(id: string, data: any) {
+  const jugador = await jugadoresService.update(id, data)
+  revalidatePath("/dashboard/jugadores")
+  return jugador
+}
+


### PR DESCRIPTION
## Summary
- Fetch team and players in attendance page using `equiposService.getByTemporada` and `jugadoresService.getByEquipo`
- Track players in reactive state and initialize attendance records when they change
- Add server actions for creating/updating players that revalidate `/dashboard/jugadores`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for Next.js ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aedf101b708320ab098c86601cf74b