### PR TITLE
Fix primary team selection across dashboard modules

### DIFF
--- a/scripts/add_match_score.sql
+++ b/scripts/add_match_score.sql
@@ -1,0 +1,2 @@
+ALTER TABLE partidos
+ADD COLUMN IF NOT EXISTS marcador JSONB;

--- a/scripts/partidos.sql
+++ b/scripts/partidos.sql
@@ -10,7 +10,8 @@ CREATE TABLE partidos (
     jornada     INTEGER,
     alineacion  JSONB NOT NULL DEFAULT '[]',
     notas_rival TEXT,
-    finalizado  BOOLEAN NOT NULL DEFAULT false
+    finalizado  BOOLEAN NOT NULL DEFAULT false,
+    marcador    JSONB
 );
 
 CREATE TABLE eventos_partido (

--- a/src/app/dashboard/asistencias/page.tsx
+++ b/src/app/dashboard/asistencias/page.tsx
@@ -440,106 +440,79 @@ export default function AsistenciasPage() {
         </Button>
       </div>
 
-      <div className="grid gap-6 rounded-xl border bg-card text-card-foreground shadow-sm lg:grid-cols-[minmax(0,320px),minmax(0,1fr)]">
-        <div className="space-y-6 border-b border-muted/40 p-6 lg:border-b-0 lg:border-r">
-          <Card>
-            <CardHeader className="flex items-start gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-                <CalendarClock className="h-5 w-5 text-primary" />
-              </div>
-              <div>
-                <CardTitle>Gestiona el calendario</CardTitle>
-                <CardDescription>
-                  Programa nuevas sesiones y gestiona reprogramaciones desde la sección de entrenamientos.
-                </CardDescription>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <p className="text-sm text-muted-foreground">
-                Aquí podrás consultar el calendario existente y registrar la asistencia. Para crear, editar o eliminar
-                entrenamientos recurre al módulo dedicado y mantén este panel centrado en el seguimiento diario del
-                equipo.
-              </p>
-              <Button asChild className="w-full">
-                <Link href="/dashboard/entrenamientos">
-                  Abrir calendario de entrenamientos
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
-
-          <Card className="border-none shadow-none">
-            <CardHeader>
-              <CardTitle>Calendario de sesiones</CardTitle>
-              <CardDescription>Selecciona un entrenamiento para gestionar la asistencia.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-[1.5fr,1fr]">
-                <Calendar
-                  mode="single"
-                  selected={fecha}
-                  onSelect={handleSelectDate}
-                  modifiers={{ scheduled: scheduledDates }}
-                  modifiersClassNames={{ scheduled: "bg-primary/10 text-primary font-semibold" }}
-                />
-                <div className="flex flex-col gap-4">
-                  <div>
-                    <h4 className="mb-2 text-sm font-medium">Sesiones del día</h4>
-                    {sessionsForSelectedDate.length > 0 ? (
-                      <div className="space-y-2">
-                        {sessionsForSelectedDate.map((sesion) => {
-                          const inicio = new Date(sesion.inicio)
-                          return (
-                            <div
-                              key={sesion.id}
-                              className={cn(
-                                "flex items-center justify-between rounded-lg border p-3",
-                                selectedEntrenamientoId === sesion.id && "border-primary bg-primary/5"
-                              )}
-                            >
-                              <div>
-                                <div className="font-medium">
-                                  {format(inicio, "HH:mm")} {sesion.fin ? `- ${format(new Date(sesion.fin), "HH:mm")}` : ""}
-                                </div>
-                                <p className="text-sm text-muted-foreground">{formatDateLong(inicio)}</p>
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Calendario de sesiones</CardTitle>
+            <CardDescription>Selecciona un entrenamiento para gestionar la asistencia.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-[1.5fr,1fr]">
+              <Calendar
+                mode="single"
+                selected={fecha}
+                onSelect={handleSelectDate}
+                modifiers={{ scheduled: scheduledDates }}
+                modifiersClassNames={{ scheduled: "bg-primary/10 text-primary font-semibold" }}
+              />
+              <div className="flex flex-col gap-4">
+                <div>
+                  <h4 className="mb-2 text-sm font-medium">Sesiones del día</h4>
+                  {sessionsForSelectedDate.length > 0 ? (
+                    <div className="space-y-2">
+                      {sessionsForSelectedDate.map((sesion) => {
+                        const inicio = new Date(sesion.inicio)
+                        return (
+                          <div
+                            key={sesion.id}
+                            className={cn(
+                              "flex items-center justify-between rounded-lg border p-3",
+                              selectedEntrenamientoId === sesion.id && "border-primary bg-primary/5"
+                            )}
+                          >
+                            <div>
+                              <div className="font-medium">
+                                {format(inicio, "HH:mm")} {sesion.fin ? `- ${format(new Date(sesion.fin), "HH:mm")}` : ""}
                               </div>
-                              <div className="flex items-center gap-2">
-                                <Button
-                                  size="sm"
-                                  variant={selectedEntrenamientoId === sesion.id ? "default" : "outline"}
-                                  onClick={() => handleSelectEntrenamiento(sesion)}
-                                >
-                                  Seleccionar
-                                </Button>
-                                <Button
-                                  size="icon"
-                                  variant="ghost"
-                                  onClick={() => handleDeleteEntrenamiento(sesion.id)}
-                                  disabled={deletingTrainingId === sesion.id}
-                                >
-                                  {deletingTrainingId === sesion.id ? (
-                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                  ) : (
-                                    <Trash2 className="h-4 w-4" />
-                                  )}
-                                </Button>
-                              </div>
+                              <p className="text-sm text-muted-foreground">{formatDateLong(inicio)}</p>
                             </div>
-                          )
-                        })}
-                      </div>
-                    ) : (
-                      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                        <p>No hay entrenamientos programados para {selectedDateLabel}.</p>
-                        <Button asChild variant="outline" className="gap-2">
-                          <Link href={trainingPlannerHref}>
-                            <PlusCircle className="h-4 w-4" /> Programar entrenamiento
-                          </Link>
-                        </Button>
-                      </div>
-                    )}
-                  </div>
+                            <div className="flex items-center gap-2">
+                              <Button
+                                size="sm"
+                                variant={selectedEntrenamientoId === sesion.id ? "default" : "outline"}
+                                onClick={() => handleSelectEntrenamiento(sesion)}
+                              >
+                                Seleccionar
+                              </Button>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => handleDeleteEntrenamiento(sesion.id)}
+                                disabled={deletingTrainingId === sesion.id}
+                              >
+                                {deletingTrainingId === sesion.id ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Trash2 className="h-4 w-4" />
+                                )}
+                              </Button>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  ) : (
+                    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                      <p>No hay entrenamientos programados para {selectedDateLabel}.</p>
+                      <Button asChild variant="outline" className="gap-2">
+                        <Link href={trainingPlannerHref}>
+                          <PlusCircle className="h-4 w-4" /> Programar entrenamiento
+                        </Link>
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                {upcomingEntrenamientos.length > 0 ? (
                   <div>
                     <h4 className="mb-2 flex items-center justify-between text-sm font-medium">
                       Próximos entrenamientos
@@ -573,25 +546,47 @@ export default function AsistenciasPage() {
                                   event.stopPropagation()
                                   handleDeleteEntrenamiento(sesion.id)
                                 }}
+                                disabled={deletingTrainingId === sesion.id}
                               >
-                                <Trash2 className="h-4 w-4" />
+                                {deletingTrainingId === sesion.id ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Trash2 className="h-4 w-4" />
+                                )}
                               </Button>
                             </button>
                           )
                         })}
-                        {upcomingEntrenamientos.length === 0 && (
-                          <p className="p-3 text-sm text-muted-foreground">
-                            No hay entrenamientos próximos programados.
-                          </p>
-                        )}
                       </div>
                     </ScrollArea>
                   </div>
-                </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+                    No hay entrenamientos próximos programados.
+                  </div>
+                )}
               </div>
-            </CardContent>
-          </Card>
-        </div>
+            </div>
+            {!selectedEntrenamiento && (
+              <Card className="border-dashed">
+                <CardContent className="flex flex-col items-center justify-center gap-3 py-6 text-center text-sm text-muted-foreground">
+                  <CalendarClock className="h-8 w-8 text-muted-foreground" />
+                  <div>
+                    Selecciona un entrenamiento del calendario para registrar asistencia.
+                    <br />
+                    También puedes programar una nueva sesión desde el planificador.
+                  </div>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={trainingPlannerHref}>
+                      Programar entrenamiento
+                      <PlusCircle className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+          </CardContent>
+        </Card>
 
         <Card id="asistencias" className="flex flex-col">
           <div className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">

--- a/src/app/dashboard/asistencias/page.tsx
+++ b/src/app/dashboard/asistencias/page.tsx
@@ -15,6 +15,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
+import { resolvePrimaryTeam } from "@/lib/team"
 
 interface Jugador {
   id: string
@@ -183,7 +184,7 @@ export default function AsistenciasPage() {
       const temporada = await temporadaRes.json()
       setTemporadaActual(temporada?.id || "")
       const equipos = await equiposRes.json()
-      const eq = equipos[0]
+      const eq = resolvePrimaryTeam(equipos || [])
       setEquipo(eq)
       if (eq) {
         const jRes = await fetch(`/api/jugadores?equipoId=${eq.id}`, { cache: "no-store" })

--- a/src/app/dashboard/entrenamientos/page.tsx
+++ b/src/app/dashboard/entrenamientos/page.tsx
@@ -44,6 +44,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
+import { resolvePrimaryTeam } from "@/lib/team"
 
 interface Entrenamiento {
   id: number
@@ -384,7 +385,7 @@ export default function EntrenamientosPage() {
         const temporada = await temporadaRes.json()
         setTemporadaActual(temporada?.id || "")
         const equipos = await equiposRes.json()
-        const eq = equipos[0]
+        const eq = resolvePrimaryTeam(equipos || [])
         setEquipo(eq ?? null)
         if (eq?.id) {
           const horariosRes = await fetch(`/api/horarios?equipoId=${eq.id}`, { cache: "no-store" })

--- a/src/app/dashboard/entrenamientos/page.tsx
+++ b/src/app/dashboard/entrenamientos/page.tsx
@@ -194,7 +194,7 @@ function addMinutesToTime(time: string, minutes: number) {
   return format(result, "HH:mm")
 }
 
-export default function EntrenamientosPage() {
+function EntrenamientosPageContent() {
   const [temporadaActual, setTemporadaActual] = React.useState<string>("")
   const [equipo, setEquipo] = React.useState<any | null>(null)
   const [entrenamientos, setEntrenamientos] = React.useState<Entrenamiento[]>([])
@@ -1093,5 +1093,20 @@ export default function EntrenamientosPage() {
         </Collapsible>
       </div>
     </>
+  )
+}
+
+export default function EntrenamientosPage() {
+  return (
+    <React.Suspense
+      fallback={
+        <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 p-6 text-muted-foreground">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <span>Cargando planificador…</span>
+        </div>
+      }
+    >
+      <EntrenamientosPageContent />
+    </React.Suspense>
   )
 }

--- a/src/app/dashboard/jugadores/page.tsx
+++ b/src/app/dashboard/jugadores/page.tsx
@@ -1,10 +1,11 @@
 import { equiposService, jugadoresService } from "@/lib/api/services"
 import JugadoresList from "./jugadores-list"
+import { resolvePrimaryTeam } from "@/lib/team"
 
 export const dynamic = "force-dynamic"
 
 export default async function JugadoresPage() {
-  const equipo = (await equiposService.getAll())[0]
+  const equipo = resolvePrimaryTeam(await equiposService.getAll())
   const jugadores = equipo ? await jugadoresService.getByEquipo(equipo.id) : []
   return <JugadoresList jugadores={jugadores} equipoNombre={equipo?.nombre || ''} />
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import {
   rivalesService,
   sancionesService,
 } from "@/lib/api/services"
+import { resolvePrimaryTeam } from "@/lib/team"
 import { listMatches } from "@/lib/api/matches"
 import type { Match, MatchEvent } from "@/types/match"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
@@ -171,7 +172,7 @@ async function safeListMatches(): Promise<Match[]> {
 
 export default async function DashboardPage() {
   const equipos = await equiposService.getAll()
-  const equipo = equipos[0]
+  const equipo = resolvePrimaryTeam(equipos)
 
   const [jugadores, horarios, entrenamientos, rivales, storedSanctions, matches] = await Promise.all([
     equipo ? jugadoresService.getByEquipo(equipo.id) : Promise.resolve([]),

--- a/src/app/dashboard/partidos/[id]/edit/page.tsx
+++ b/src/app/dashboard/partidos/[id]/edit/page.tsx
@@ -1,0 +1,159 @@
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+
+import { getMatch, updateMatch } from "@/lib/api/matches";
+import {
+  equiposService,
+  jugadoresService,
+  rivalesService,
+} from "@/lib/api/services";
+import { getFormationPositions, detectFormation } from "@/lib/formations";
+import MatchForm from "../../match-form";
+import type { FormationKey } from "@/lib/formations";
+import type { PlayerSlot } from "@/types/match";
+
+function getContrastColor(hex: string) {
+  const c = hex.replace("#", "");
+  const r = parseInt(c.substring(0, 2), 16);
+  const g = parseInt(c.substring(2, 4), 16);
+  const b = parseInt(c.substring(4, 6), 16);
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq >= 128 ? "#000" : "#fff";
+}
+
+export default async function EditMatchPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const id = Number(params.id);
+  const match = await getMatch(id);
+  if (!match) {
+    return <div className="p-4">Partido no encontrado</div>;
+  }
+
+  const [rivales, players, equipo] = await Promise.all([
+    rivalesService.getAll(),
+    jugadoresService.getByEquipo(match.teamId),
+    equiposService.getById(match.teamId),
+  ]);
+
+  const teamColor = equipo?.color || "#dc2626";
+  const GOALKEEPER_COLOR = "#16a34a";
+  const textColor = getContrastColor(teamColor);
+
+  const formationKey = detectFormation(match.lineup) as FormationKey;
+  const formationPositions = getFormationPositions(formationKey);
+
+  const starters = formationPositions
+    .map((pos) =>
+      match.lineup.find(
+        (slot) => slot.role === "field" && slot.position === pos
+      )
+    )
+    .map((slot) => (slot && slot.playerId != null ? slot.playerId : null))
+    .filter((playerId): playerId is number => playerId != null);
+
+  const bench = match.lineup
+    .filter((slot) => slot.role === "bench" && slot.playerId != null)
+    .map((slot) => slot.playerId as number);
+
+  async function actualizarPartido(formData: FormData) {
+    "use server";
+    const condicion = formData.get("condicion") as string;
+    const opponentIdRaw = formData.get("opponentId") as string;
+    let opponentId = Number(opponentIdRaw);
+
+    if (opponentIdRaw === "new") {
+      const nombre = formData.get("newTeamName") as string;
+      const color = formData.get("newTeamColor") as string;
+      const nuevo = await rivalesService.create({ nombre, color });
+      opponentId = nuevo.id;
+    }
+
+    const kickoff = formData.get("kickoff") as string;
+    const competition = formData.get("competition") as
+      | "liga"
+      | "playoff"
+      | "copa"
+      | "amistoso";
+    const matchdayRaw = formData.get("matchday");
+    const matchday = matchdayRaw ? Number(matchdayRaw) : null;
+    const startersSelected = formData.getAll("starters").map((v) => Number(v));
+    const benchSelected = formData.getAll("bench").map((v) => Number(v));
+    const formationKeySelected =
+      ((formData.get("formation") as string) || formationKey) as FormationKey;
+
+    const isHome = condicion === "home";
+
+    const formationSelected = getFormationPositions(formationKeySelected);
+    const lineup: PlayerSlot[] = [];
+    startersSelected.slice(0, formationSelected.length).forEach((playerId, idx) => {
+      const player = players.find((p: any) => p.id === playerId);
+      lineup.push({
+        playerId,
+        number: player?.dorsal ?? undefined,
+        role: "field",
+        position: formationSelected[idx],
+        minutes: 0,
+      });
+    });
+    benchSelected.forEach((playerId) => {
+      const player = players.find((p: any) => p.id === playerId);
+      if (player) {
+        lineup.push({
+          playerId,
+          number: player.dorsal ?? undefined,
+          role: "bench",
+          position: undefined,
+          minutes: 0,
+        });
+      }
+    });
+
+    await updateMatch(id, {
+      rivalId: opponentId,
+      isHome,
+      kickoff,
+      competition,
+      matchday,
+      lineup,
+    });
+
+    revalidatePath("/dashboard/partidos");
+    revalidatePath(`/dashboard/partidos/${id}`);
+
+    const nextStep = formData.get("next");
+    if (nextStep === "start") {
+      redirect(`/dashboard/partidos/${id}`);
+    }
+    redirect("/dashboard/partidos");
+  }
+
+  return (
+    <div className="p-4 lg:p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Editar Partido</h1>
+      <MatchForm
+        players={players}
+        rivales={rivales}
+        action={actualizarPartido}
+        teamColor={teamColor}
+        goalkeeperColor={GOALKEEPER_COLOR}
+        textColor={textColor}
+        defaults={{
+          condicion: match.isHome ? "home" : "away",
+          opponentId: match.rivalId,
+          competition: match.competition,
+          matchday: match.matchday ?? undefined,
+          kickoff: match.kickoff,
+          formation: formationKey,
+          starters,
+          bench,
+        }}
+        primaryLabel="Guardar cambios"
+        startLabel="Guardar e iniciar"
+        showStartButton
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/partidos/[id]/edit/page.tsx
+++ b/src/app/dashboard/partidos/[id]/edit/page.tsx
@@ -38,6 +38,18 @@ export default async function EditMatchPage({
     equiposService.getById(match.teamId),
   ]);
 
+  const simplifiedPlayers = players.map((player: any) => ({
+    id: Number(player.id),
+    nombre: player.nombre as string,
+    posicion: player.posicion ?? null,
+    dorsal: player.dorsal ?? null,
+  }));
+  const simplifiedRivals = rivales.map((team: any) => ({
+    id: Number(team.id),
+    nombre: team.nombre as string,
+    color: team.color ?? null,
+  }));
+
   const teamColor = equipo?.color || "#dc2626";
   const GOALKEEPER_COLOR = "#16a34a";
   const textColor = getContrastColor(teamColor);
@@ -157,8 +169,8 @@ export default async function EditMatchPage({
     <div className="p-4 lg:p-6 space-y-6">
       <h1 className="text-2xl font-semibold">Editar Partido</h1>
       <MatchForm
-        players={players}
-        rivales={rivales}
+        players={simplifiedPlayers}
+        rivales={simplifiedRivals}
         action={actualizarPartido}
         teamColor={teamColor}
         goalkeeperColor={GOALKEEPER_COLOR}

--- a/src/app/dashboard/partidos/[id]/match-detail.tsx
+++ b/src/app/dashboard/partidos/[id]/match-detail.tsx
@@ -43,7 +43,7 @@ import {
   Flag,
   List,
   ArrowLeft,
-  SquarePen,
+  PenSquare,
 } from "lucide-react";
 import {
   FORMATION_OPTIONS,
@@ -575,7 +575,7 @@ export default function MatchDetail({
           </Button>
           <Button asChild variant="outline" size="sm" className="gap-1">
             <Link href={`/dashboard/partidos/${match.id}/edit`}>
-              <SquarePen className="h-4 w-4" /> Editar partido
+              <PenSquare className="h-4 w-4" /> Editar partido
             </Link>
           </Button>
         </div>

--- a/src/app/dashboard/partidos/[id]/match-detail.tsx
+++ b/src/app/dashboard/partidos/[id]/match-detail.tsx
@@ -407,6 +407,21 @@ export default function MatchDetail({
       })),
     ];
 
+    const activeIds = new Set(lineupPayload.map((slot) => slot.playerId));
+    match.lineup
+      .filter((slot) => slot.role === "excluded" && slot.playerId != null)
+      .forEach((slot) => {
+        if (!activeIds.has(slot.playerId as number)) {
+          lineupPayload.push({
+            playerId: slot.playerId as number,
+            number: playerMap[slot.playerId as number]?.dorsal ?? undefined,
+            role: "excluded",
+            position: slot.position,
+            minutes: Math.floor((stats[slot.playerId as number]?.minutes ?? 0) / 60),
+          });
+        }
+      });
+
     await saveLineup(lineupPayload, true);
     router.push(`/dashboard/partidos`);
   }

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -1,4 +1,7 @@
-import type { Match } from "@/types/match";
+import Link from "next/link";
+
+import type { Match, MatchEvent, MatchScore } from "@/types/match";
+
 interface Player {
   id: number;
   nombre: string;
@@ -7,59 +10,261 @@ interface Player {
 interface Props {
   match: Match;
   players: Player[];
+  homeTeamName: string;
+  awayTeamName: string;
+  homeTeamColor: string;
+  awayTeamColor: string;
 }
 
-export default function MatchSummary({ match, players }: Props) {
+function resolveScore(match: Match): MatchScore {
+  if (match.score) {
+    return match.score;
+  }
+  const teamGoals = match.events.filter(
+    (e) => e.type === "gol" && e.teamId === match.teamId
+  ).length;
+  const rivalGoals = match.events.filter(
+    (e) => e.type === "gol" && e.rivalId === match.rivalId
+  ).length;
+  return { team: teamGoals, rival: rivalGoals };
+}
+
+function formatEvent(
+  event: MatchEvent,
+  playerMap: Record<number, Player>,
+  params: {
+    match: Match;
+    homeTeamName: string;
+    awayTeamName: string;
+  }
+) {
+  const { match, homeTeamName, awayTeamName } = params;
+  const ourTeamName = match.isHome ? homeTeamName : awayTeamName;
+  const rivalTeamName = match.isHome ? awayTeamName : homeTeamName;
+  const playerName =
+    event.playerId != null ? playerMap[event.playerId]?.nombre : undefined;
+  const isOurTeam = event.teamId === match.teamId;
+  const isRivalTeam = event.rivalId === match.rivalId;
+
+  switch (event.type) {
+    case "gol": {
+      const teamLabel = isOurTeam ? ourTeamName : rivalTeamName;
+      const subject = playerName ?? teamLabel ?? "";
+      const teamSuffix = playerName && teamLabel ? ` (${teamLabel})` : "";
+      return {
+        icon: "⚽",
+        description: `Gol de ${subject}${teamSuffix}`,
+      };
+    }
+    case "amarilla": {
+      const teamLabel = isOurTeam ? ourTeamName : rivalTeamName;
+      const subject = playerName ?? teamLabel ?? "";
+      const teamSuffix = playerName && teamLabel ? ` (${teamLabel})` : "";
+      return {
+        icon: "🟨",
+        description: `Tarjeta amarilla para ${subject}${teamSuffix}`,
+      };
+    }
+    case "roja": {
+      const teamLabel = isOurTeam ? ourTeamName : rivalTeamName;
+      const subject = playerName ?? teamLabel ?? "";
+      const teamSuffix = playerName && teamLabel ? ` (${teamLabel})` : "";
+      return {
+        icon: "🟥",
+        description: `Tarjeta roja para ${subject}${teamSuffix}`,
+      };
+    }
+    case "cambio": {
+      const data = (event.data ?? {}) as {
+        in?: number;
+        out?: number;
+      };
+      const playerIn =
+        (data.in != null ? playerMap[data.in] : undefined) ??
+        (playerName ? { nombre: playerName } : undefined);
+      const playerOut = data.out != null ? playerMap[data.out] : undefined;
+      const teamLabel = isOurTeam ? ourTeamName : rivalTeamName;
+      return {
+        icon: "🔁",
+        description: `Cambio en ${teamLabel}: entra ${
+          playerIn?.nombre ?? "jugador"
+        }${playerOut ? `, sale ${playerOut.nombre}` : ""}`,
+      };
+    }
+    default: {
+      if (isOurTeam) {
+        return {
+          icon: "•",
+          description: `${event.type} ${playerName ? `- ${playerName}` : ""}`,
+        };
+      }
+      if (isRivalTeam) {
+        return {
+          icon: "•",
+          description: `${event.type} rival ${
+            playerName ? `- ${playerName}` : ""
+          }`,
+        };
+      }
+      return { icon: "•", description: event.type };
+    }
+  }
+}
+
+function sortLineupByMinutes(match: Match) {
+  return [...match.lineup].sort((a, b) => b.minutes - a.minutes);
+}
+
+export default function MatchSummary({
+  match,
+  players,
+  homeTeamName,
+  awayTeamName,
+  homeTeamColor,
+  awayTeamColor,
+}: Props) {
   const playerMap = Object.fromEntries(players.map((p) => [p.id, p]));
+  const score = resolveScore(match);
+  const homeGoals = match.isHome ? score.team : score.rival;
+  const awayGoals = match.isHome ? score.rival : score.team;
+  const sortedLineup = sortLineupByMinutes(match);
+  const timelineEvents = [...match.events].sort((a, b) => {
+    if (a.minute === b.minute) {
+      return a.id - b.id;
+    }
+    return a.minute - b.minute;
+  });
+
   return (
-    <div className="p-4 space-y-6">
-      <section>
-        <h2 className="text-lg font-semibold">Timeline</h2>
-        <ol className="space-y-1">
-          {match.events.map((e) => (
-            <li key={e.id}>
-              {e.minute}&apos; {e.type}
-              {e.playerId ? ` - ${playerMap[e.playerId]?.nombre ?? ''}` : ''}
-            </li>
-          ))}
-        </ol>
-      </section>
-      <section>
-        <h2 className="text-lg font-semibold">Minutos jugados</h2>
-        <table className="w-full text-sm">
-          <tbody>
-            {match.lineup.map((slot) => {
-              const player = slot.playerId ? playerMap[slot.playerId] : null;
-              if (!player) return null;
+    <div className="p-4 lg:p-6 space-y-8">
+      <header className="rounded-lg border bg-card text-card-foreground shadow-sm">
+        <div className="grid gap-4 p-4 sm:grid-cols-3 sm:items-center">
+          <div
+            className="rounded-md p-3 text-center sm:text-left"
+            style={{ backgroundColor: homeTeamColor }}
+          >
+            <p className="text-sm font-medium text-white/80">Local</p>
+            <p className="text-lg font-semibold text-white">{homeTeamName}</p>
+          </div>
+          <div className="flex flex-col items-center justify-center gap-2">
+            <span className="text-3xl font-bold tabular-nums">
+              {homeGoals} - {awayGoals}
+            </span>
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">
+              Resultado final
+            </span>
+          </div>
+          <div
+            className="rounded-md p-3 text-center sm:text-right"
+            style={{ backgroundColor: awayTeamColor }}
+          >
+            <p className="text-sm font-medium text-white/80">Visitante</p>
+            <p className="text-lg font-semibold text-white">{awayTeamName}</p>
+          </div>
+        </div>
+      </header>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Cronología del partido</h2>
+          <span className="text-xs text-muted-foreground">
+            Cambios, tarjetas y goles en orden cronológico
+          </span>
+        </div>
+        {timelineEvents.length === 0 ? (
+          <p className="rounded-md border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+            No se registraron eventos en este partido.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {timelineEvents.map((event) => {
+              const { icon, description } = formatEvent(event, playerMap, {
+                match,
+                homeTeamName,
+                awayTeamName,
+              });
               return (
-                <tr key={slot.playerId} className="border-b last:border-b-0">
-                  <td className="py-1">{player.nombre}</td>
-                  <td className="py-1 text-right">{slot.minutes}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </section>
-      <section>
-        <h2 className="text-lg font-semibold">Valoraciones</h2>
-        <ul className="space-y-1">
-          {match.lineup
-            .filter((l) => l.playerId && l.minutes > 0)
-            .map((l) => {
-              const p = playerMap[l.playerId as number];
-              return (
-                <li key={l.playerId}>
-                  <a
-                    className="text-blue-600 underline"
-                    href={`/dashboard/valoraciones?jugador=${l.playerId}`}
-                  >
-                    Valorar a {p?.nombre}
-                  </a>
+                <li
+                  key={event.id}
+                  className="flex items-start gap-3 rounded-md border px-3 py-2 text-sm"
+                >
+                  <span className="mt-0.5 text-base">{icon}</span>
+                  <div className="flex-1">
+                    <p className="font-medium tabular-nums">
+                      {event.minute}
+                      <span aria-hidden="true">′</span>
+                    </p>
+                    <p className="text-muted-foreground">{description}</p>
+                  </div>
                 </li>
               );
             })}
-        </ul>
+          </ol>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Minutos jugados</h2>
+        <div className="overflow-hidden rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2">Jugador</th>
+                <th className="px-3 py-2">Rol</th>
+                <th className="px-3 py-2 text-right">Minutos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedLineup.map((slot) => {
+                if (!slot.playerId) return null;
+                const player = playerMap[slot.playerId];
+                if (!player) return null;
+                const roleLabel =
+                  slot.role === "field"
+                    ? "Titular"
+                    : slot.role === "bench"
+                    ? "Suplente"
+                    : "Desconvocado";
+                return (
+                  <tr key={slot.playerId} className="border-t">
+                    <td className="px-3 py-2">{player.nombre}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{roleLabel}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {slot.minutes}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Acciones posteriores</h2>
+        <div className="flex flex-wrap gap-2">
+          {match.lineup
+            .filter((slot) => slot.playerId && slot.minutes > 0)
+            .map((slot) => {
+              const player = playerMap[slot.playerId as number];
+              if (!player) return null;
+              return (
+                <Link
+                  key={slot.playerId}
+                  className="rounded-md border px-3 py-2 text-sm text-blue-600 transition hover:bg-blue-50"
+                  href={`/dashboard/valoraciones?jugador=${slot.playerId}`}
+                >
+                  Valorar a {player.nombre}
+                </Link>
+              );
+            })}
+          <Link
+            href="/dashboard/partidos"
+            className="ml-auto rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90"
+          >
+            Volver al listado
+          </Link>
+        </div>
       </section>
     </div>
   );

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
 import type { Match, MatchEvent, MatchScore } from "@/types/match";
 
 interface Player {
@@ -136,7 +137,27 @@ export default function MatchSummary({
   });
 
   return (
-    <div className="p-4 lg:p-6 space-y-8">
+    <div className="space-y-8 px-4 py-6 lg:px-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="ghost" size="sm" className="gap-1">
+            <Link href="/dashboard/partidos">
+              ← Volver al listado
+            </Link>
+          </Button>
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="gap-1"
+          >
+            <Link href={`/dashboard/partidos/${match.id}/edit`}>
+              Editar partido
+            </Link>
+          </Button>
+        </div>
+      </div>
+
       <header className="rounded-lg border bg-card text-card-foreground shadow-sm">
         <div className="grid gap-4 p-4 sm:grid-cols-3 sm:items-center">
           <div
@@ -258,12 +279,9 @@ export default function MatchSummary({
                 </Link>
               );
             })}
-          <Link
-            href="/dashboard/partidos"
-            className="ml-auto rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90"
-          >
-            Volver al listado
-          </Link>
+          <Button asChild className="ml-auto">
+            <Link href="/dashboard/partidos">Volver al listado</Link>
+          </Button>
         </div>
       </section>
     </div>

--- a/src/app/dashboard/partidos/[id]/page.tsx
+++ b/src/app/dashboard/partidos/[id]/page.tsx
@@ -16,7 +16,7 @@ export default async function MatchPage({ params }: MatchPageProps) {
   if (!match) {
     return <div className="p-4">Partido no encontrado</div>;
   }
-  const allPlayers = await jugadoresService.getByEquipo(1);
+  const allPlayers = await jugadoresService.getByEquipo(match.teamId);
   const selectedIds = match.lineup.map((l) => l.playerId);
   const players = match.lineup.length
     ? allPlayers.filter((p) => selectedIds.includes(p.id))

--- a/src/app/dashboard/partidos/match-form.tsx
+++ b/src/app/dashboard/partidos/match-form.tsx
@@ -29,6 +29,7 @@ interface MatchFormDefaults {
   formation?: string;
   starters?: number[];
   bench?: number[];
+  excluded?: number[];
 }
 
 interface MatchFormProps {
@@ -87,6 +88,7 @@ export default function MatchForm({
           textColor={textColor}
           defaultStarters={defaults?.starters ?? []}
           defaultBench={defaults?.bench ?? []}
+          defaultExcluded={defaults?.excluded ?? []}
           maxStarters={11}
         />
       </div>

--- a/src/app/dashboard/partidos/match-form.tsx
+++ b/src/app/dashboard/partidos/match-form.tsx
@@ -1,0 +1,177 @@
+import PlayerSelector from "./new/player-selector";
+import OpponentSelect from "./new/opponent-select";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  FORMATION_OPTIONS,
+  DEFAULT_FORMATION_KEY,
+} from "@/lib/formations";
+
+interface Player {
+  id: number;
+  nombre: string;
+  posicion: string | null;
+  dorsal: number | null;
+}
+
+interface Rival {
+  id: number;
+  nombre: string;
+  color?: string | null;
+}
+
+interface MatchFormDefaults {
+  condicion?: "home" | "away";
+  opponentId?: number | null;
+  competition?: "liga" | "playoff" | "copa" | "amistoso";
+  matchday?: number | null;
+  kickoff?: string | null;
+  formation?: string;
+  starters?: number[];
+  bench?: number[];
+}
+
+interface MatchFormProps {
+  players: Player[];
+  rivales: Rival[];
+  action: (formData: FormData) => Promise<void>;
+  teamColor: string;
+  goalkeeperColor: string;
+  textColor: string;
+  defaults?: MatchFormDefaults;
+  primaryLabel?: string;
+  startLabel?: string;
+  showStartButton?: boolean;
+}
+
+const TEAM_COLORS = [
+  { value: "#dc2626", label: "Rojo" },
+  { value: "#1d4ed8", label: "Azul" },
+  { value: "#15803d", label: "Verde" },
+  { value: "#f59e0b", label: "Amarillo" },
+  { value: "#000000", label: "Negro" },
+  { value: "#ffffff", label: "Blanco" },
+];
+
+function formatDateTimeLocal(value?: string | null) {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  const offsetMinutes = date.getTimezoneOffset();
+  const localDate = new Date(date.getTime() - offsetMinutes * 60 * 1000);
+  return localDate.toISOString().slice(0, 16);
+}
+
+export default function MatchForm({
+  players,
+  rivales,
+  action,
+  teamColor,
+  goalkeeperColor,
+  textColor,
+  defaults,
+  primaryLabel = "Guardar partido",
+  startLabel = "Guardar e iniciar",
+  showStartButton = true,
+}: MatchFormProps) {
+  const kickoffValue = formatDateTimeLocal(defaults?.kickoff ?? undefined);
+  const formationValue = defaults?.formation ?? DEFAULT_FORMATION_KEY;
+
+  return (
+    <form action={action} className="flex flex-col lg:flex-row gap-6">
+      <div className="flex-1">
+        <PlayerSelector
+          players={players}
+          teamColor={teamColor}
+          goalkeeperColor={goalkeeperColor}
+          textColor={textColor}
+          defaultStarters={defaults?.starters ?? []}
+          defaultBench={defaults?.bench ?? []}
+          maxStarters={11}
+        />
+      </div>
+      <div className="w-full max-w-xs space-y-4">
+        <h2 className="font-semibold">Información del partido</h2>
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Formación</label>
+          <select
+            name="formation"
+            className="w-full rounded border p-2"
+            defaultValue={formationValue}
+          >
+            {FORMATION_OPTIONS.map((option) => (
+              <option key={option.key} value={option.key}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-muted-foreground">
+            La formación muestra solo a los jugadores de campo. El portero se
+            añade automáticamente.
+          </p>
+        </div>
+        <div className="space-y-1">
+          <label className="text-sm font-medium">
+            ¿Dónde se juega el partido?
+          </label>
+          <select
+            name="condicion"
+            className="w-full rounded border p-2"
+            defaultValue={defaults?.condicion ?? "home"}
+            required
+          >
+            <option value="home">Local</option>
+            <option value="away">Visitante</option>
+          </select>
+        </div>
+        <OpponentSelect
+          teams={rivales}
+          colors={TEAM_COLORS}
+          defaultOpponentId={defaults?.opponentId}
+        />
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Tipo de competición</label>
+          <select
+            name="competition"
+            className="w-full rounded border p-2"
+            defaultValue={defaults?.competition ?? "liga"}
+            required
+          >
+            <option value="liga">Liga</option>
+            <option value="playoff">Play Off</option>
+            <option value="copa">Copa</option>
+            <option value="amistoso">Amistoso</option>
+          </select>
+        </div>
+        <Input
+          type="number"
+          name="matchday"
+          placeholder="Jornada"
+          defaultValue={defaults?.matchday ?? undefined}
+        />
+        <Input
+          type="datetime-local"
+          name="kickoff"
+          required
+          defaultValue={kickoffValue}
+        />
+        <div className="flex flex-col gap-2">
+          <Button type="submit" name="next" value="list" className="w-full">
+            {primaryLabel}
+          </Button>
+          {showStartButton && (
+            <Button
+              type="submit"
+              variant="secondary"
+              name="next"
+              value="start"
+              className="w-full"
+            >
+              {startLabel}
+            </Button>
+          )}
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/app/dashboard/partidos/new/opponent-select.tsx
+++ b/src/app/dashboard/partidos/new/opponent-select.tsx
@@ -13,7 +13,17 @@ interface ColorOption {
   label: string;
 }
 
-export default function OpponentSelect({ teams, colors }: { teams: Team[]; colors: ColorOption[] }) {
+interface OpponentSelectProps {
+  teams: Team[];
+  colors: ColorOption[];
+  defaultOpponentId?: number | null;
+}
+
+export default function OpponentSelect({
+  teams,
+  colors,
+  defaultOpponentId,
+}: OpponentSelectProps) {
   const [isNew, setIsNew] = useState(false);
 
   return (
@@ -23,6 +33,9 @@ export default function OpponentSelect({ teams, colors }: { teams: Team[]; color
         name="opponentId"
         className="w-full rounded border p-2"
         required
+        defaultValue={
+          defaultOpponentId != null ? String(defaultOpponentId) : ""
+        }
         onChange={(e) => setIsNew(e.target.value === "new")}
       >
         <option value="">Seleccione rival</option>

--- a/src/app/dashboard/partidos/new/page.tsx
+++ b/src/app/dashboard/partidos/new/page.tsx
@@ -53,6 +53,7 @@ export default async function NuevoPartidoPage() {
     const matchday = matchdayRaw ? Number(matchdayRaw) : null;
     const starters = formData.getAll("starters").map((v) => Number(v));
     const bench = formData.getAll("bench").map((v) => Number(v));
+    const excluded = formData.getAll("excluded").map((v) => Number(v));
     const formationKey =
       ((formData.get("formation") as string) || DEFAULT_FORMATION_KEY) as FormationKey;
 
@@ -78,6 +79,19 @@ export default async function NuevoPartidoPage() {
           playerId: id,
           number: pl.dorsal ?? undefined,
           role: "bench",
+          position: undefined,
+          minutes: 0,
+        });
+      }
+    });
+
+    excluded.forEach((id) => {
+      const pl = allPlayers.find((p: any) => p.id === id);
+      if (pl) {
+        lineup.push({
+          playerId: id,
+          number: pl.dorsal ?? undefined,
+          role: "excluded",
           position: undefined,
           minutes: 0,
         });

--- a/src/app/dashboard/partidos/new/page.tsx
+++ b/src/app/dashboard/partidos/new/page.tsx
@@ -21,6 +21,17 @@ export default async function NuevoPartidoPage() {
 
   const rivales = await rivalesService.getAll();
   const players = await jugadoresService.getByEquipo(nuestro.id);
+  const simplifiedPlayers = players.map((player: any) => ({
+    id: Number(player.id),
+    nombre: player.nombre as string,
+    posicion: player.posicion ?? null,
+    dorsal: player.dorsal ?? null,
+  }));
+  const simplifiedRivals = rivales.map((team: any) => ({
+    id: Number(team.id),
+    nombre: team.nombre as string,
+    color: team.color ?? null,
+  }));
   const teamColor = nuestro?.color || '#dc2626';
   const GOALKEEPER_COLOR = '#16a34a';
 
@@ -120,8 +131,8 @@ export default async function NuevoPartidoPage() {
     <div className="p-4 lg:p-6 space-y-6">
       <h1 className="text-2xl font-semibold">Nuevo Partido</h1>
       <MatchForm
-        players={players}
-        rivales={rivales}
+        players={simplifiedPlayers}
+        rivales={simplifiedRivals}
         action={crearPartido}
         teamColor={teamColor}
         goalkeeperColor={GOALKEEPER_COLOR}

--- a/src/app/dashboard/partidos/new/page.tsx
+++ b/src/app/dashboard/partidos/new/page.tsx
@@ -122,6 +122,7 @@ export default async function NuevoPartidoPage() {
       matchday,
       lineup,
       events: [],
+      score: null,
     });
     revalidatePath("/dashboard/partidos");
     const nextStep = formData.get("next");

--- a/src/app/dashboard/partidos/new/page.tsx
+++ b/src/app/dashboard/partidos/new/page.tsx
@@ -1,13 +1,15 @@
 import { equiposService, jugadoresService, rivalesService } from "@/lib/api/services";
 import { createMatch } from "@/lib/api/matches";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import PlayerSelector from "./player-selector";
-import OpponentSelect from "./opponent-select";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import type { PlayerSlot } from "@/types/match";
 import { getPrimaryTeamId, resolvePrimaryTeam } from "@/lib/team";
+import MatchForm from "../match-form";
+import {
+  DEFAULT_FORMATION_KEY,
+  getFormationPositions,
+} from "@/lib/formations";
+import type { FormationKey } from "@/lib/formations";
 
 export default async function NuevoPartidoPage() {
   const equipos = await equiposService.getAll();
@@ -32,15 +34,6 @@ export default async function NuevoPartidoPage() {
   }
   const textColor = getContrastColor(teamColor);
 
-  const TEAM_COLORS = [
-    { value: '#dc2626', label: 'Rojo' },
-    { value: '#1d4ed8', label: 'Azul' },
-    { value: '#15803d', label: 'Verde' },
-    { value: '#f59e0b', label: 'Amarillo' },
-    { value: '#000000', label: 'Negro' },
-    { value: '#ffffff', label: 'Blanco' },
-  ];
-
   async function crearPartido(formData: FormData) {
     "use server";
     const condicion = formData.get("condicion") as string; // home or away
@@ -60,11 +53,13 @@ export default async function NuevoPartidoPage() {
     const matchday = matchdayRaw ? Number(matchdayRaw) : null;
     const starters = formData.getAll("starters").map((v) => Number(v));
     const bench = formData.getAll("bench").map((v) => Number(v));
+    const formationKey =
+      ((formData.get("formation") as string) || DEFAULT_FORMATION_KEY) as FormationKey;
 
     const isHome = condicion === "home";
 
     const allPlayers = await jugadoresService.getByEquipo(nuestro.id);
-    const formation = ["GK", "LB", "LCB", "RCB", "RB", "LM", "CM", "RM", "LW", "ST", "RW"];
+    const formation = getFormationPositions(formationKey);
     const lineup: PlayerSlot[] = [];
     starters.slice(0, formation.length).forEach((id, idx) => {
       const pl = allPlayers.find((p: any) => p.id === id);
@@ -89,7 +84,7 @@ export default async function NuevoPartidoPage() {
       }
     });
 
-    await createMatch({
+    const created = await createMatch({
       teamId: nuestro.id,
       rivalId: opponentId,
       isHome,
@@ -100,57 +95,27 @@ export default async function NuevoPartidoPage() {
       events: [],
     });
     revalidatePath("/dashboard/partidos");
+    const nextStep = formData.get("next");
+    if (nextStep === "start") {
+      redirect(`/dashboard/partidos/${created.id}`);
+    }
     redirect("/dashboard/partidos");
   }
 
   return (
     <div className="p-4 lg:p-6 space-y-6">
       <h1 className="text-2xl font-semibold">Nuevo Partido</h1>
-      <form action={crearPartido} className="flex flex-col lg:flex-row gap-6">
-        <div className="flex-1">
-          <PlayerSelector
-            players={players}
-            teamColor={teamColor}
-            goalkeeperColor={GOALKEEPER_COLOR}
-            textColor={textColor}
-          />
-        </div>
-        <div className="w-full max-w-xs space-y-4">
-          <h2 className="font-semibold">Información del partido</h2>
-          <div className="space-y-1">
-            <label className="text-sm font-medium">
-              ¿Dónde se juega el partido?
-            </label>
-            <select
-              name="condicion"
-              className="w-full rounded border p-2"
-              required
-            >
-              <option value="home">Local</option>
-              <option value="away">Visitante</option>
-            </select>
-          </div>
-          <OpponentSelect teams={rivales} colors={TEAM_COLORS} />
-          <div className="space-y-1">
-            <label className="text-sm font-medium">Tipo de competición</label>
-            <select
-              name="competition"
-              className="w-full rounded border p-2"
-              required
-            >
-              <option value="liga">Liga</option>
-              <option value="playoff">Play Off</option>
-              <option value="copa">Copa</option>
-              <option value="amistoso">Amistoso</option>
-            </select>
-          </div>
-          <Input type="number" name="matchday" placeholder="Jornada" />
-          <Input type="datetime-local" name="kickoff" required />
-          <Button type="submit" className="w-full">
-            Continuar
-          </Button>
-        </div>
-      </form>
+      <MatchForm
+        players={players}
+        rivales={rivales}
+        action={crearPartido}
+        teamColor={teamColor}
+        goalkeeperColor={GOALKEEPER_COLOR}
+        textColor={textColor}
+        primaryLabel="Crear partido"
+        startLabel="Crear e iniciar"
+        showStartButton
+      />
     </div>
   );
 }

--- a/src/app/dashboard/partidos/new/page.tsx
+++ b/src/app/dashboard/partidos/new/page.tsx
@@ -71,24 +71,29 @@ export default async function NuevoPartidoPage() {
     const isHome = condicion === "home";
 
     const allPlayers = await jugadoresService.getByEquipo(nuestro.id);
+    const dorsalLookup = allPlayers.reduce<Record<number, number | undefined>>(
+      (acc, player: any) => {
+        acc[player.id] = player.dorsal ?? undefined;
+        return acc;
+      },
+      {}
+    );
     const formation = getFormationPositions(formationKey);
     const lineup: PlayerSlot[] = [];
     starters.slice(0, formation.length).forEach((id, idx) => {
-      const pl = allPlayers.find((p: any) => p.id === id);
       lineup.push({
         playerId: id,
-        number: pl?.dorsal ?? undefined,
+        number: dorsalLookup[id],
         role: "field",
         position: formation[idx],
         minutes: 0,
       });
     });
     bench.forEach((id) => {
-      const pl = allPlayers.find((p: any) => p.id === id);
-      if (pl) {
+      if (id in dorsalLookup) {
         lineup.push({
           playerId: id,
-          number: pl.dorsal ?? undefined,
+          number: dorsalLookup[id],
           role: "bench",
           position: undefined,
           minutes: 0,
@@ -97,11 +102,10 @@ export default async function NuevoPartidoPage() {
     });
 
     excluded.forEach((id) => {
-      const pl = allPlayers.find((p: any) => p.id === id);
-      if (pl) {
+      if (id in dorsalLookup) {
         lineup.push({
           playerId: id,
-          number: pl.dorsal ?? undefined,
+          number: dorsalLookup[id],
           role: "excluded",
           position: undefined,
           minutes: 0,

--- a/src/app/dashboard/partidos/new/player-selector.tsx
+++ b/src/app/dashboard/partidos/new/player-selector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface Player {
   id: number
@@ -14,17 +14,40 @@ interface Props {
   teamColor: string
   goalkeeperColor: string
   textColor: string
+  defaultStarters?: number[]
+  defaultBench?: number[]
+  maxStarters?: number
 }
 
-export default function PlayerSelector({ players, teamColor, goalkeeperColor, textColor }: Props) {
+export default function PlayerSelector({
+  players,
+  teamColor,
+  goalkeeperColor,
+  textColor,
+  defaultStarters = [],
+  defaultBench = [],
+  maxStarters = 11,
+}: Props) {
   const [tab, setTab] = useState<'starters' | 'bench'>('starters')
-  const [starters, setStarters] = useState<number[]>([])
-  const [bench, setBench] = useState<number[]>([])
+  const [starters, setStarters] = useState<number[]>(defaultStarters)
+  const [bench, setBench] = useState<number[]>(defaultBench)
+
+  useEffect(() => {
+    setStarters(defaultStarters)
+  }, [defaultStarters])
+
+  useEffect(() => {
+    setBench(defaultBench)
+  }, [defaultBench])
 
   function toggle(id: number) {
     if (tab === 'starters') {
       setStarters(prev =>
-        prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+        prev.includes(id)
+          ? prev.filter(p => p !== id)
+          : prev.length >= maxStarters
+            ? prev
+            : [...prev, id]
       )
       setBench(prev => prev.filter(p => p !== id))
     } else {
@@ -60,7 +83,7 @@ export default function PlayerSelector({ players, teamColor, goalkeeperColor, te
               : 'bg-muted text-muted-foreground'
           }`}
         >
-          Titulares ({starters.length})
+          Titulares ({starters.length}/{maxStarters})
         </button>
         <button
           type="button"

--- a/src/app/dashboard/partidos/new/player-selector.tsx
+++ b/src/app/dashboard/partidos/new/player-selector.tsx
@@ -16,6 +16,7 @@ interface Props {
   textColor: string
   defaultStarters?: number[]
   defaultBench?: number[]
+  defaultExcluded?: number[]
   maxStarters?: number
 }
 
@@ -26,11 +27,13 @@ export default function PlayerSelector({
   textColor,
   defaultStarters = [],
   defaultBench = [],
+  defaultExcluded = [],
   maxStarters = 11,
 }: Props) {
-  const [tab, setTab] = useState<'starters' | 'bench'>('starters')
+  const [tab, setTab] = useState<'starters' | 'bench' | 'excluded'>('starters')
   const [starters, setStarters] = useState<number[]>(defaultStarters)
   const [bench, setBench] = useState<number[]>(defaultBench)
+  const [excluded, setExcluded] = useState<number[]>(defaultExcluded)
 
   useEffect(() => {
     setStarters(defaultStarters)
@@ -39,6 +42,10 @@ export default function PlayerSelector({
   useEffect(() => {
     setBench(defaultBench)
   }, [defaultBench])
+
+  useEffect(() => {
+    setExcluded(defaultExcluded)
+  }, [defaultExcluded])
 
   function toggle(id: number) {
     if (tab === 'starters') {
@@ -50,23 +57,35 @@ export default function PlayerSelector({
             : [...prev, id]
       )
       setBench(prev => prev.filter(p => p !== id))
-    } else {
+      setExcluded(prev => prev.filter(p => p !== id))
+    } else if (tab === 'bench') {
       setBench(prev =>
         prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
       )
       setStarters(prev => prev.filter(p => p !== id))
+      setExcluded(prev => prev.filter(p => p !== id))
+    } else {
+      setExcluded(prev =>
+        prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+      )
+      setStarters(prev => prev.filter(p => p !== id))
+      setBench(prev => prev.filter(p => p !== id))
     }
   }
 
   const cardHighlight = (id: number) => {
     const isStarter = starters.includes(id)
     const isBench = bench.includes(id)
+    const isExcluded = excluded.includes(id)
     if (tab === 'starters') {
       if (isStarter) return 'ring-2 ring-primary'
-      if (isBench) return 'opacity-40'
-    } else {
+      if (isBench || isExcluded) return 'opacity-40'
+    } else if (tab === 'bench') {
       if (isBench) return 'ring-2 ring-primary'
-      if (isStarter) return 'opacity-40'
+      if (isStarter || isExcluded) return 'opacity-40'
+    } else {
+      if (isExcluded) return 'ring-2 ring-red-500'
+      if (isStarter || isBench) return 'opacity-40'
     }
     return ''
   }
@@ -95,6 +114,17 @@ export default function PlayerSelector({
           }`}
         >
           Suplentes ({bench.length})
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('excluded')}
+          className={`px-3 py-1 rounded-full text-sm transition-colors ${
+            tab === 'excluded'
+              ? 'bg-destructive text-destructive-foreground'
+              : 'bg-muted text-muted-foreground'
+          }`}
+        >
+          Desconvocados ({excluded.length})
         </button>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
@@ -126,6 +156,9 @@ export default function PlayerSelector({
       ))}
       {bench.map(id => (
         <input key={`b-${id}`} type="hidden" name="bench" value={id} />
+      ))}
+      {excluded.map(id => (
+        <input key={`e-${id}`} type="hidden" name="excluded" value={id} />
       ))}
     </div>
   )

--- a/src/app/dashboard/partidos/partidos-list.tsx
+++ b/src/app/dashboard/partidos/partidos-list.tsx
@@ -80,12 +80,17 @@ export default function PartidosList({ matches, teamMap }: PartidosListProps) {
             {filtered.map((match) => {
               const rival = teamMap[match.rivalId] || String(match.rivalId);
               const isHome = match.isHome;
-              const teamGoals = match.events.filter(
-                (e) => e.type === "gol" && e.teamId === match.teamId
-              ).length;
-              const rivalGoals = match.events.filter(
-                (e) => e.type === "gol" && e.rivalId === match.rivalId
-              ).length;
+              const score = match.score;
+              const teamGoals =
+                score?.team ??
+                match.events.filter(
+                  (e) => e.type === "gol" && e.teamId === match.teamId
+                ).length;
+              const rivalGoals =
+                score?.rival ??
+                match.events.filter(
+                  (e) => e.type === "gol" && e.rivalId === match.rivalId
+                ).length;
               const ourGoals = teamGoals;
               const theirGoals = rivalGoals;
               const hasLineup = match.lineup.some((slot) => slot.role === "field");

--- a/src/app/dashboard/partidos/partidos-list.tsx
+++ b/src/app/dashboard/partidos/partidos-list.tsx
@@ -88,6 +88,12 @@ export default function PartidosList({ matches, teamMap }: PartidosListProps) {
               ).length;
               const ourGoals = teamGoals;
               const theirGoals = rivalGoals;
+              const hasLineup = match.lineup.some((slot) => slot.role === "field");
+              const detailLabel = match.finished
+                ? "Resumen"
+                : hasLineup
+                ? "Continuar"
+                : "Iniciar";
               const homeGoals = isHome ? teamGoals : rivalGoals;
               const awayGoals = isHome ? rivalGoals : teamGoals;
               let result = "-";
@@ -110,9 +116,18 @@ export default function PartidosList({ matches, teamMap }: PartidosListProps) {
                   <TableCell>{rival}</TableCell>
                   <TableCell className={resultColor}>{result}</TableCell>
                   <TableCell className="text-right">
-                    <Button variant="ghost" size="sm" asChild>
-                      <Link href={`/dashboard/partidos/${match.id}`}>Ver</Link>
-                    </Button>
+                    <div className="flex justify-end gap-2">
+                      <Button variant="ghost" size="sm" asChild>
+                        <Link href={`/dashboard/partidos/${match.id}/edit`}>
+                          Editar
+                        </Link>
+                      </Button>
+                      <Button variant="ghost" size="sm" asChild>
+                        <Link href={`/dashboard/partidos/${match.id}`}>
+                          {detailLabel}
+                        </Link>
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               );

--- a/src/app/dashboard/valoraciones/page.tsx
+++ b/src/app/dashboard/valoraciones/page.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge"
 import { Textarea } from "@/components/ui/textarea"
 import { Separator } from "@/components/ui/separator"
+import { resolvePrimaryTeam } from "@/lib/team"
 
 // Datos iniciales cargados desde la API
 
@@ -88,7 +89,7 @@ export default function ValoracionesPage() {
       .then(data => setValoraciones(data))
     const cargarDatos = async () => {
       const equipos = await fetch('/api/equipos', { cache: 'no-store' }).then(res => res.json())
-      const eq = equipos[0]
+      const eq = resolvePrimaryTeam(equipos || [])
       setEquipo(eq)
       if (eq) {
         const js = await fetch(`/api/jugadores?equipoId=${eq.id}`, { cache: 'no-store' }).then(res => res.json())

--- a/src/app/dashboard/valoraciones/page.tsx
+++ b/src/app/dashboard/valoraciones/page.tsx
@@ -13,6 +13,11 @@ import { resolvePrimaryTeam } from "@/lib/team"
 
 // Datos iniciales cargados desde la API
 
+interface Equipo {
+  id: number
+  nombre: string
+}
+
 // Aptitudes a valorar
 const aptitudes = [
   { id: "tecnica", nombre: "Técnica" },
@@ -75,7 +80,7 @@ interface Valoracion {
 }
 
 export default function ValoracionesPage() {
-  const [equipo, setEquipo] = React.useState<any | null>(null)
+  const [equipo, setEquipo] = React.useState<Equipo | null>(null)
   const [jugadoresBase, setJugadoresBase] = React.useState<any[]>([])
   const [trimestreActual, setTrimestreActual] = React.useState(trimestres[0].id)
   const [filtroJugadores, setFiltroJugadores] = React.useState("todos")
@@ -88,8 +93,8 @@ export default function ValoracionesPage() {
       .then(res => res.json())
       .then(data => setValoraciones(data))
     const cargarDatos = async () => {
-      const equipos = await fetch('/api/equipos', { cache: 'no-store' }).then(res => res.json())
-      const eq = resolvePrimaryTeam(equipos || [])
+      const equipos: Equipo[] = await fetch('/api/equipos', { cache: 'no-store' }).then(res => res.json())
+      const eq = resolvePrimaryTeam<Equipo>(equipos || [])
       setEquipo(eq)
       if (eq) {
         const js = await fetch(`/api/jugadores?equipoId=${eq.id}`, { cache: 'no-store' }).then(res => res.json())

--- a/src/lib/formations.ts
+++ b/src/lib/formations.ts
@@ -1,0 +1,104 @@
+import type { PlayerSlot } from "@/types/match";
+
+export type FormationKey = "3-5-2" | "4-3-3" | "4-4-2";
+
+interface FormationOption {
+  key: FormationKey;
+  label: string;
+  /**
+   * Ordered list of position codes used when laying out the starting lineup.
+   * The goalkeeper (GK) is always included as the first entry even though it
+   * is not reflected in the textual formation label.
+   */
+  positions: string[];
+}
+
+export const FORMATION_OPTIONS: FormationOption[] = [
+  {
+    key: "3-5-2",
+    label: "3-5-2",
+    positions: [
+      "GK",
+      "LCB",
+      "CB",
+      "RCB",
+      "LWB",
+      "LCM",
+      "CM",
+      "RCM",
+      "RWB",
+      "LS",
+      "RS",
+    ],
+  },
+  {
+    key: "4-3-3",
+    label: "4-3-3",
+    positions: [
+      "GK",
+      "LB",
+      "LCB",
+      "RCB",
+      "RB",
+      "LCM",
+      "CM",
+      "RCM",
+      "LW",
+      "ST",
+      "RW",
+    ],
+  },
+  {
+    key: "4-4-2",
+    label: "4-4-2",
+    positions: [
+      "GK",
+      "LB",
+      "LCB",
+      "RCB",
+      "RB",
+      "LM",
+      "LCM",
+      "RCM",
+      "RM",
+      "LS",
+      "RS",
+    ],
+  },
+];
+
+export const DEFAULT_FORMATION_KEY: FormationKey = "3-5-2";
+
+export const FORMATIONS_MAP: Record<FormationKey, string[]> = FORMATION_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.key] = option.positions;
+    return acc;
+  },
+  {} as Record<FormationKey, string[]>
+);
+
+export function getFormationPositions(key: FormationKey | string): string[] {
+  if (key in FORMATIONS_MAP) {
+    return FORMATIONS_MAP[key as FormationKey];
+  }
+  return FORMATIONS_MAP[DEFAULT_FORMATION_KEY];
+}
+
+export function detectFormation(lineup: PlayerSlot[]): FormationKey {
+  const fieldPositions = lineup
+    .filter((slot) => slot.role === "field" && slot.position)
+    .map((slot) => slot.position as string);
+
+  for (const option of FORMATION_OPTIONS) {
+    if (fieldPositions.length !== option.positions.length) {
+      continue;
+    }
+    const fieldSet = new Set(fieldPositions);
+    const matches = option.positions.every((pos) => fieldSet.has(pos));
+    if (matches) {
+      return option.key;
+    }
+  }
+
+  return DEFAULT_FORMATION_KEY;
+}

--- a/src/lib/team.ts
+++ b/src/lib/team.ts
@@ -1,0 +1,30 @@
+const DEFAULT_PRIMARY_TEAM_ID = 2;
+
+function parseEnvTeamId(value: string | undefined | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+export function getPrimaryTeamId(): number {
+  const envId =
+    parseEnvTeamId(process.env.NEXT_PUBLIC_PRIMARY_TEAM_ID) ??
+    parseEnvTeamId(process.env.PRIMARY_TEAM_ID);
+
+  if (envId !== undefined) {
+    return envId;
+  }
+
+  return DEFAULT_PRIMARY_TEAM_ID;
+}
+
+export function resolvePrimaryTeam<T extends { id: number }>(teams: T[]): T | null {
+  if (!Array.isArray(teams) || teams.length === 0) {
+    return null;
+  }
+
+  const primaryTeamId = getPrimaryTeamId();
+  const match = teams.find((team) => Number(team.id) === primaryTeamId);
+  return match ?? teams[0] ?? null;
+}

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -20,6 +20,13 @@ export interface PlayerSlot {
   enterSecond?: number;
 }
 
+export interface MatchScore {
+  /** Goles anotados por nuestro equipo. */
+  team: number;
+  /** Goles encajados frente al rival. */
+  rival: number;
+}
+
 export interface MatchEvent {
   id: number;
   matchId: number;
@@ -51,6 +58,8 @@ export interface Match {
   opponentNotes?: string | null;
   /** Indicates whether the match has concluded. */
   finished: boolean;
+  /** Resultado final almacenado al cierre del partido. */
+  score: MatchScore | null;
 }
 
 export type NewMatch = Omit<Match, 'id' | 'finished'>;

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -7,7 +7,7 @@ export interface PlayerSlot {
   /**
    * Indicates whether the player starts on the field or the bench.
    */
-  role: 'field' | 'bench';
+  role: 'field' | 'bench' | 'excluded';
   /** Shorthand position code (e.g. GK, LB, ST) used for visual layout. */
   position?: string;
   /** Minutes played by the player in this match. */


### PR DESCRIPTION
## Summary
- centralize the primary team resolution with environment-based fallback to the cadete team
- ensure new matches, match management and dashboard sections load players and data for the resolved primary team
- update client dashboards to pick the configured team instead of assuming the first entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5092acebc832083d1e0d31dbbd345