### PR TITLE
Fix dashboard schedule cards and improve player management

### DIFF
--- a/src/app/dashboard/jugadores/[id]/page.tsx
+++ b/src/app/dashboard/jugadores/[id]/page.tsx
@@ -12,6 +12,8 @@ import { RatingStars } from "@/components/rating-stars"
 import { PlayerRadarChart } from "@/components/player-radar-chart"
 import { revalidatePath } from "next/cache"
 
+const POSITIONS = ["Portero", "Defensa", "Centrocampista", "Delantero"]
+
 export default async function JugadorPage({ params }: { params: { id: string } }) {
   const jugadorId = Number(params.id)
   const jugador = await jugadoresService.getById(jugadorId)
@@ -50,7 +52,9 @@ export default async function JugadorPage({ params }: { params: { id: string } }
     "use server"
     const nombre = formData.get("nombre") as string
     const posicion = formData.get("posicion") as string
-    await jugadoresService.update(jugadorId, { nombre, posicion })
+    const dorsalRaw = formData.get("dorsal")
+    const dorsal = dorsalRaw !== null && dorsalRaw !== "" ? Number(dorsalRaw) : null
+    await jugadoresService.update(jugadorId, { nombre, posicion, dorsal })
     revalidatePath(`/dashboard/jugadores/${jugadorId}`)
     revalidatePath('/dashboard/jugadores')
   }
@@ -138,13 +142,47 @@ export default async function JugadorPage({ params }: { params: { id: string } }
               action={actualizarJugador}
             >
               <Input name="nombre" defaultValue={jugador.nombre} placeholder="Nombre" />
-              <Input name="posicion" defaultValue={jugador.posicion} placeholder="Posición" />
+              <div className="grid gap-2 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-muted-foreground" htmlFor="player-position">
+                    Posición
+                  </label>
+                  <select
+                    id="player-position"
+                    name="posicion"
+                    defaultValue={jugador.posicion}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {POSITIONS.map((position) => (
+                      <option key={position} value={position}>
+                        {position}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-muted-foreground" htmlFor="player-number">
+                    Dorsal
+                  </label>
+                  <Input
+                    id="player-number"
+                    name="dorsal"
+                    type="number"
+                    min={1}
+                    defaultValue={jugador.dorsal ?? ""}
+                    placeholder="Número"
+                  />
+                </div>
+              </div>
               <DialogFooter><Button type="submit">Guardar</Button></DialogFooter>
             </FormDialog>
           </CardHeader>
           <CardContent className="space-y-1 text-sm">
             <div><span className="font-medium">Nombre:</span> {jugador.nombre}</div>
             <div><span className="font-medium">Posición:</span> {jugador.posicion}</div>
+            <div>
+              <span className="font-medium">Dorsal:</span> {jugador.dorsal ?? "Sin asignar"}
+            </div>
             <div><span className="font-medium">Asistencias:</span> {presentes}/{totalSesiones} ({porcentajeAsistencia}%)</div>
           </CardContent>
         </Card>

--- a/src/app/dashboard/jugadores/jugadores-list.tsx
+++ b/src/app/dashboard/jugadores/jugadores-list.tsx
@@ -20,16 +20,22 @@ interface Jugador {
   id: number
   nombre: string
   posicion: string
+  dorsal?: number | null
 }
 
 export default function JugadoresList({ jugadores, equipoNombre }: { jugadores: Jugador[]; equipoNombre: string }) {
   const [searchQuery, setSearchQuery] = React.useState("")
 
-  const filtered = jugadores.filter(
-    (jugador) =>
-      jugador.nombre.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      jugador.posicion.toLowerCase().includes(searchQuery.toLowerCase())
-  )
+  const filtered = jugadores.filter((jugador) => {
+    const query = searchQuery.toLowerCase().trim()
+    if (!query) return true
+    const dorsal = jugador.dorsal ? String(jugador.dorsal) : ""
+    return (
+      jugador.nombre.toLowerCase().includes(query) ||
+      jugador.posicion.toLowerCase().includes(query) ||
+      dorsal.includes(query)
+    )
+  })
 
   return (
     <>
@@ -62,40 +68,51 @@ export default function JugadoresList({ jugadores, equipoNombre }: { jugadores: 
       </div>
 
       <div className="grid grid-cols-1 gap-4 px-4 sm:grid-cols-2 md:grid-cols-3 lg:px-6">
-        {filtered.map((jugador, index) => (
-          <Link key={jugador.id} href={`/dashboard/jugadores/${jugador.id}`}>
-            <Card className="h-full overflow-hidden transition-colors hover:bg-muted/50">
-              <CardHeader className="border-b p-4">
-                <div className="flex justify-between">
-                  <div>
-                    <CardTitle className="text-lg">{jugador.nombre}</CardTitle>
-                    <CardDescription>{jugador.posicion}</CardDescription>
+        {filtered.map((jugador, index) => {
+          const normalizedPosition = jugador.posicion?.toLowerCase().trim()
+          const isGoalkeeper = normalizedPosition === "portero"
+          const dorsal = jugador.dorsal ?? index + 1
+          return (
+            <Link key={jugador.id} href={`/dashboard/jugadores/${jugador.id}`}>
+              <Card
+                className={cn(
+                  "h-full overflow-hidden transition-colors hover:bg-muted/50",
+                  isGoalkeeper ? "border-[hsl(var(--cdsa-green))]/40" : "border-primary/40"
+                )}
+              >
+                <CardHeader className="border-b p-4">
+                  <div className="flex justify-between">
+                    <div>
+                      <CardTitle className="text-lg">{jugador.nombre}</CardTitle>
+                      <CardDescription>{jugador.posicion}</CardDescription>
+                    </div>
+                    <div
+                      className={cn(
+                        "flex h-8 w-8 items-center justify-center rounded-full text-primary-foreground",
+                        isGoalkeeper
+                          ? "bg-[hsl(var(--cdsa-green))]"
+                          : "bg-red-600"
+                      )}
+                    >
+                      {dorsal}
+                    </div>
                   </div>
-                  <div
-                    className={cn(
-                      "flex h-8 w-8 items-center justify-center rounded-full text-primary-foreground",
-                      jugador.posicion.toLowerCase() === "portero"
-                        ? "bg-[hsl(var(--cdsa-green))]"
-                        : "bg-red-600"
-                    )}
-                  >
-                    {index + 1}
+                </CardHeader>
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>Ver detalles del jugador</span>
+                    <span className="font-medium text-foreground">#{dorsal}</span>
                   </div>
-                </div>
-              </CardHeader>
-              <CardContent className="p-4">
-                <p className="text-sm text-muted-foreground">
-                  Ver detalles del jugador
-                </p>
-              </CardContent>
-              <CardFooter className="border-t bg-muted/50 p-4">
-                <Button variant="ghost" className="w-full" asChild>
-                  <div>Ver ficha completa</div>
-                </Button>
-              </CardFooter>
-            </Card>
-          </Link>
-        ))}
+                </CardContent>
+                <CardFooter className="border-t bg-muted/50 p-4">
+                  <Button variant="ghost" className="w-full" asChild>
+                    <div>Ver ficha completa</div>
+                  </Button>
+                </CardFooter>
+              </Card>
+            </Link>
+          )
+        })}
         {filtered.length === 0 && (
           <Card className="col-span-full">
             <CardContent className="p-4 text-center text-sm text-muted-foreground">

--- a/src/app/dashboard/jugadores/new/page.tsx
+++ b/src/app/dashboard/jugadores/new/page.tsx
@@ -4,6 +4,8 @@ import { Input } from "@/components/ui/input";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 
+const POSITIONS = ["Portero", "Defensa", "Centrocampista", "Delantero"];
+
 export default async function NuevoJugadorPage() {
   const equipo = (await equiposService.getAll())[0];
 
@@ -11,8 +13,10 @@ export default async function NuevoJugadorPage() {
     "use server";
     const nombre = formData.get("nombre") as string;
     const posicion = formData.get("posicion") as string;
+    const dorsalRaw = formData.get("dorsal");
+    const dorsal = dorsalRaw !== null && dorsalRaw !== "" ? Number(dorsalRaw) : null;
     const equipoId = equipo?.id ?? Number(formData.get("equipoId"));
-    await jugadoresService.create({ nombre, posicion, equipoId });
+    await jugadoresService.create({ nombre, posicion, equipoId, dorsal });
     revalidatePath("/dashboard/jugadores");
     redirect("/dashboard/jugadores");
   }
@@ -26,7 +30,31 @@ export default async function NuevoJugadorPage() {
       <h1 className="text-2xl font-semibold">Nuevo Jugador</h1>
       <form action={crearJugador} className="space-y-4">
         <Input name="nombre" placeholder="Nombre" required />
-        <Input name="posicion" placeholder="Posición" required />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-muted-foreground" htmlFor="new-player-position">
+              Posición
+            </label>
+            <select
+              id="new-player-position"
+              name="posicion"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              defaultValue={POSITIONS[0]}
+            >
+              {POSITIONS.map((position) => (
+                <option key={position} value={position}>
+                  {position}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-muted-foreground" htmlFor="new-player-number">
+              Dorsal
+            </label>
+            <Input id="new-player-number" name="dorsal" type="number" min={1} placeholder="Número" />
+          </div>
+        </div>
         <input type="hidden" name="equipoId" value={equipo.id} />
         <Button type="submit">Crear</Button>
       </form>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -198,7 +198,7 @@ export default async function DashboardPage() {
   }
 
   const teamMatches = (matches as Match[]).filter((match) =>
-    equipo ? match.teamId === equipo.id : true
+    equipo ? Number(match.teamId) === Number(equipo.id) : true
   )
 
   const now = new Date()

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -57,10 +57,10 @@ const seedPlayers = async (equipoId: number) => {
     ['Alejandro Puente Mauleón', 'Delantero'],
     ['David Albert Fañanás', 'Delantero'],
   ];
-  for (const [nombre, posicion] of jugadores) {
+  for (const [index, [nombre, posicion]] of jugadores.entries()) {
     await db.query(
-      'INSERT INTO jugadores (nombre, posicion, equipoId, logs) VALUES ($1,$2,$3,$4)',
-      [nombre, posicion, equipoId, '{}']
+      'INSERT INTO jugadores (nombre, posicion, equipoId, logs, dorsal) VALUES ($1,$2,$3,$4,$5)',
+      [nombre, posicion, equipoId, '{}', index + 1]
     );
   }
 };
@@ -83,8 +83,10 @@ export const ready = (async () => {
       nombre TEXT NOT NULL,
       posicion TEXT,
       equipoId INTEGER REFERENCES equipos(id),
-      logs TEXT
+      logs TEXT,
+      dorsal INTEGER
     )`);
+    await db.query('ALTER TABLE jugadores ADD COLUMN IF NOT EXISTS dorsal INTEGER');
     await db.query(`CREATE TABLE IF NOT EXISTS asistencias (
       id SERIAL PRIMARY KEY,
       jugadorId INTEGER REFERENCES jugadores(id),

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -57,7 +57,8 @@ const seedPlayers = async (equipoId: number) => {
     ['Alejandro Puente Mauleón', 'Delantero'],
     ['David Albert Fañanás', 'Delantero'],
   ];
-  for (const [index, [nombre, posicion]] of jugadores.entries()) {
+  for (let index = 0; index < jugadores.length; index += 1) {
+    const [nombre, posicion] = jugadores[index];
     await db.query(
       'INSERT INTO jugadores (nombre, posicion, equipoId, logs, dorsal) VALUES ($1,$2,$3,$4,$5)',
       [nombre, posicion, equipoId, '{}', index + 1]


### PR DESCRIPTION
## Summary
- ensure the dashboard filters upcoming matches with numeric team ids so scheduled fixtures appear
- normalize training schedule filtering and persist player dorsals in the data layer, including seeding defaults
- expose dorsal numbers throughout the squad UI and allow editing/creating players with number and position selectors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65971d2608320af62b369512dd146