### PR TITLE
Improve match substitutions on tablets

### DIFF
--- a/src/app/dashboard/partidos/[id]/page.tsx
+++ b/src/app/dashboard/partidos/[id]/page.tsx
@@ -16,7 +16,9 @@ export default async function MatchPage({ params }: MatchPageProps) {
   if (!match) {
     return <div className="p-4">Partido no encontrado</div>;
   }
-  const allPlayers = await jugadoresService.getByEquipo(1);
+  const allPlayers = match.teamId
+    ? await jugadoresService.getByEquipo(match.teamId)
+    : [];
   const selectedIds = match.lineup.map((l) => l.playerId);
   const players = match.lineup.length
     ? allPlayers.filter((p) => selectedIds.includes(p.id))


### PR DESCRIPTION
## Summary
- add assist quick action and display all player event icons consistently in the match view
- introduce bench player selection with a change dialog as an alternative to drag-and-drop substitutions
- keep the bench limited to convoked players, sorted by dorsal, and update the list after every swap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c5a9c024832082948102c3cf868c