### PR TITLE
Improve match setup workflow and summary visuals

### DIFF
--- a/src/app/dashboard/partidos/[id]/editar/page.tsx
+++ b/src/app/dashboard/partidos/[id]/editar/page.tsx
@@ -58,6 +58,8 @@ export default async function EditarPartidoPage({ params }: PageProps) {
     redirect(`/dashboard/partidos/${matchId}`);
   }
 
+  const opponentNotes = match.opponentNotes ?? null;
+
   const equipo = await equiposService.getById(match.teamId);
   const jugadores = await jugadoresService.getByEquipo(match.teamId);
   const players: SelectorPlayer[] = jugadores.map((player: any) => ({
@@ -154,7 +156,7 @@ export default async function EditarPartidoPage({ params }: PageProps) {
         });
       });
 
-    await updateLineup(matchId, lineup, match.opponentNotes ?? null, false);
+    await updateLineup(matchId, lineup, opponentNotes, false);
     revalidatePath(`/dashboard/partidos/${matchId}`);
     revalidatePath("/dashboard/partidos");
     redirect("/dashboard/partidos");

--- a/src/app/dashboard/partidos/[id]/editar/page.tsx
+++ b/src/app/dashboard/partidos/[id]/editar/page.tsx
@@ -1,0 +1,198 @@
+import { notFound, redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+
+import { getMatch, updateLineup } from "@/lib/api/matches";
+import { jugadoresService, equiposService } from "@/lib/api/services";
+import PlayerSelector from "@/app/dashboard/partidos/new/player-selector";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PlayerSlot } from "@/types/match";
+import {
+  DEFAULT_FORMATION_KEY,
+  FORMATIONS,
+  FORMATION_OPTIONS,
+  type FormationKey,
+} from "@/data/formations";
+
+interface PageProps {
+  params: { id: string };
+}
+
+type SelectorPlayer = {
+  id: number;
+  nombre: string;
+  posicion: string | null;
+  dorsal: number | null;
+};
+
+function inferFormationKey(lineup: PlayerSlot[]): FormationKey {
+  const fieldPositions = lineup
+    .filter((slot) => slot.role === "field" && slot.position)
+    .map((slot) => slot.position as string);
+
+  if (!fieldPositions.length) {
+    return DEFAULT_FORMATION_KEY;
+  }
+
+  const normalized = [...fieldPositions].sort().join("|");
+
+  for (const key of Object.keys(FORMATIONS) as FormationKey[]) {
+    const candidate = [...FORMATIONS[key].positions].sort().join("|");
+    if (candidate === normalized) {
+      return key;
+    }
+  }
+
+  return DEFAULT_FORMATION_KEY;
+}
+
+export default async function EditarPartidoPage({ params }: PageProps) {
+  const matchId = Number(params.id);
+  const match = await getMatch(matchId);
+
+  if (!match) {
+    notFound();
+  }
+
+  if (match.finished) {
+    redirect(`/dashboard/partidos/${matchId}`);
+  }
+
+  const equipo = await equiposService.getById(match.teamId);
+  const jugadores = await jugadoresService.getByEquipo(match.teamId);
+  const players: SelectorPlayer[] = jugadores.map((player: any) => ({
+    id: player.id,
+    nombre: player.nombre,
+    posicion: player.posicion ?? null,
+    dorsal: player.dorsal ?? null,
+  }));
+
+  const initialStarters = match.lineup
+    .filter((slot) => slot.role === "field" && slot.playerId != null)
+    .map((slot) => slot.playerId as number);
+  const initialBench = match.lineup
+    .filter((slot) => slot.role === "bench" && slot.playerId != null)
+    .map((slot) => slot.playerId as number);
+  const initialUnavailable = match.lineup
+    .filter((slot) => slot.role === "unavailable" && slot.playerId != null)
+    .map((slot) => slot.playerId as number);
+
+  const initialFormation = inferFormationKey(match.lineup);
+  const teamColor = equipo?.color ?? "#dc2626";
+  const goalkeeperColor = "#16a34a";
+
+  function getContrastColor(hex: string) {
+    const c = hex.replace("#", "");
+    const r = parseInt(c.substring(0, 2), 16);
+    const g = parseInt(c.substring(2, 4), 16);
+    const b = parseInt(c.substring(4, 6), 16);
+    const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+    return yiq >= 128 ? "#000" : "#fff";
+  }
+
+  const textColor = getContrastColor(teamColor);
+  const minutesMap = new Map<number, number>(
+    match.lineup
+      .filter((slot) => slot.playerId != null)
+      .map((slot) => [slot.playerId as number, slot.minutes ?? 0])
+  );
+  const dorsalMap = new Map<number, number | null>(
+    players.map((player) => [player.id, player.dorsal ?? null])
+  );
+
+  async function guardarConvocatoria(formData: FormData) {
+    "use server";
+
+    const starters = formData.getAll("starters").map((v) => Number(v));
+    const bench = formData.getAll("bench").map((v) => Number(v));
+    const unavailable = formData.getAll("unavailable").map((v) => Number(v));
+    const formationKey = (formData.get("formation") as string) || initialFormation;
+    const formation =
+      FORMATIONS[formationKey as FormationKey]?.positions ??
+      FORMATIONS[initialFormation].positions;
+
+    const uniqueStarters = Array.from(new Set(starters));
+    const uniqueBench = Array.from(new Set(bench));
+    const uniqueUnavailable = Array.from(new Set(unavailable));
+
+    const lineup: PlayerSlot[] = [];
+
+    uniqueStarters.slice(0, formation.length).forEach((id, idx) => {
+      if (!id) return;
+      lineup.push({
+        playerId: id,
+        number: dorsalMap.get(id) ?? undefined,
+        role: "field",
+        position: formation[idx],
+        minutes: minutesMap.get(id) ?? 0,
+      });
+    });
+
+    uniqueBench
+      .filter((id) => id && !uniqueStarters.includes(id))
+      .forEach((id) => {
+        lineup.push({
+          playerId: id,
+          number: dorsalMap.get(id) ?? undefined,
+          role: "bench",
+          position: undefined,
+          minutes: minutesMap.get(id) ?? 0,
+        });
+      });
+
+    uniqueUnavailable
+      .filter((id) =>
+        id && !uniqueStarters.includes(id) && !uniqueBench.includes(id)
+      )
+      .forEach((id) => {
+        lineup.push({
+          playerId: id,
+          number: dorsalMap.get(id) ?? undefined,
+          role: "unavailable",
+          position: undefined,
+          minutes: 0,
+        });
+      });
+
+    await updateLineup(matchId, lineup, match.opponentNotes ?? null, false);
+    revalidatePath(`/dashboard/partidos/${matchId}`);
+    revalidatePath("/dashboard/partidos");
+    redirect("/dashboard/partidos");
+  }
+
+  return (
+    <div className="p-4 lg:p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Editar convocatoria</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={guardarConvocatoria} className="flex flex-col gap-6 lg:flex-row">
+            <div className="flex-1">
+              <PlayerSelector
+                players={players}
+                teamColor={teamColor}
+                goalkeeperColor={goalkeeperColor}
+                textColor={textColor}
+                formations={FORMATION_OPTIONS}
+                defaultFormation={DEFAULT_FORMATION_KEY}
+                initialStarters={initialStarters as number[]}
+                initialBench={initialBench as number[]}
+                initialUnavailable={initialUnavailable as number[]}
+                initialFormation={initialFormation}
+              />
+            </div>
+            <div className="w-full max-w-xs space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Ajusta la lista de titulares, suplentes y desconvocados antes de iniciar el partido.
+              </p>
+              <Button type="submit" className="w-full">
+                Guardar cambios
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -1,4 +1,22 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import type { Match } from "@/types/match";
+import type { LucideIcon } from "lucide-react";
+import {
+  Clock3,
+  Goal,
+  Octagon,
+  Sparkles,
+  Square,
+} from "lucide-react";
+
 interface Player {
   id: number;
   nombre: string;
@@ -9,58 +27,290 @@ interface Props {
   players: Player[];
 }
 
+interface EventDescriptor {
+  label: string;
+  icon: LucideIcon;
+  dotClass: string;
+  pillClass: string;
+}
+
+const EVENT_CONFIG: Record<string, EventDescriptor> = {
+  gol: {
+    label: "Gol",
+    icon: Goal,
+    dotClass: "bg-emerald-500 border-emerald-200",
+    pillClass: "bg-emerald-500/10 text-emerald-600",
+  },
+  amarilla: {
+    label: "Tarjeta amarilla",
+    icon: Square,
+    dotClass: "bg-amber-400 border-amber-200",
+    pillClass: "bg-amber-500/10 text-amber-600",
+  },
+  roja: {
+    label: "Tarjeta roja",
+    icon: Octagon,
+    dotClass: "bg-red-500 border-red-200",
+    pillClass: "bg-red-500/10 text-red-600",
+  },
+  asistencia: {
+    label: "Asistencia",
+    icon: Sparkles,
+    dotClass: "bg-sky-500 border-sky-200",
+    pillClass: "bg-sky-500/10 text-sky-600",
+  },
+};
+
+const DEFAULT_EVENT: EventDescriptor = {
+  label: "Evento",
+  icon: Clock3,
+  dotClass: "bg-muted border-border",
+  pillClass: "bg-muted text-muted-foreground",
+};
+
 export default function MatchSummary({ match, players }: Props) {
-  const playerMap = Object.fromEntries(players.map((p) => [p.id, p]));
+  const playerMap = new Map(players.map((p) => [p.id, p]));
+  const starters = match.lineup
+    .filter((slot) => slot.role === "field" && slot.playerId)
+    .map((slot) => playerMap.get(slot.playerId as number))
+    .filter(Boolean) as Player[];
+  const bench = match.lineup
+    .filter((slot) => slot.role === "bench" && slot.playerId)
+    .map((slot) => playerMap.get(slot.playerId as number))
+    .filter(Boolean) as Player[];
+  const unavailable = match.lineup
+    .filter((slot) => slot.role === "unavailable" && slot.playerId)
+    .map((slot) => playerMap.get(slot.playerId as number))
+    .filter(Boolean) as Player[];
+
+  const minutesData = match.lineup
+    .filter((slot) => slot.playerId && slot.role !== "unavailable")
+    .map((slot) => ({
+      id: slot.playerId as number,
+      minutes: slot.minutes ?? 0,
+    }))
+    .filter((item) => item.minutes > 0);
+
+  const minutesSorted = [...minutesData].sort((a, b) => b.minutes - a.minutes);
+
+  const maxMinutes = minutesData.length
+    ? Math.max(90, ...minutesData.map((item) => item.minutes))
+    : 90;
+
+  const timelineEvents = [...match.events].sort((a, b) => a.minute - b.minute);
+
+  function renderPlayerList(items: Player[], emptyMessage: string) {
+    if (!items.length) {
+      return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+    }
+    const sorted = [...items].sort((a, b) => a.nombre.localeCompare(b.nombre));
+    return (
+      <ul className="mt-2 grid gap-1 text-sm text-muted-foreground">
+        {sorted.map((player) => (
+          <li key={player.id} className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-primary/60" aria-hidden />
+            <span>{player.nombre}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
   return (
     <div className="p-4 space-y-6">
-      <section>
-        <h2 className="text-lg font-semibold">Timeline</h2>
-        <ol className="space-y-1">
-          {match.events.map((e) => (
-            <li key={e.id}>
-              {e.minute}&apos; {e.type}
-              {e.playerId ? ` - ${playerMap[e.playerId]?.nombre ?? ''}` : ''}
-            </li>
-          ))}
-        </ol>
-      </section>
-      <section>
-        <h2 className="text-lg font-semibold">Minutos jugados</h2>
-        <table className="w-full text-sm">
-          <tbody>
-            {match.lineup.map((slot) => {
-              const player = slot.playerId ? playerMap[slot.playerId] : null;
-              if (!player) return null;
-              return (
-                <tr key={slot.playerId} className="border-b last:border-b-0">
-                  <td className="py-1">{player.nombre}</td>
-                  <td className="py-1 text-right">{slot.minutes}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </section>
-      <section>
-        <h2 className="text-lg font-semibold">Valoraciones</h2>
-        <ul className="space-y-1">
-          {match.lineup
-            .filter((l) => l.playerId && l.minutes > 0)
-            .map((l) => {
-              const p = playerMap[l.playerId as number];
-              return (
-                <li key={l.playerId}>
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Card className="overflow-hidden">
+          <CardHeader className="pb-4">
+            <CardTitle>Timeline del partido</CardTitle>
+            <CardDescription>
+              Resumen cronológico de los momentos clave del encuentro.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {timelineEvents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Aún no se registraron eventos para este partido.
+              </p>
+            ) : (
+              <div className="relative pl-5">
+                <div className="absolute left-2 top-0 h-full w-px bg-border" aria-hidden />
+                <ul className="space-y-6">
+                  {timelineEvents.map((event) => {
+                    const descriptor = EVENT_CONFIG[event.type] ?? DEFAULT_EVENT;
+                    const hasCustomLabel = Boolean(EVENT_CONFIG[event.type]);
+                    const Icon = descriptor.icon;
+                    const isOurEvent =
+                      event.teamId === match.teamId ||
+                      (event.playerId != null &&
+                        match.lineup.some((slot) => slot.playerId === event.playerId));
+                    const isRivalEvent = event.rivalId === match.rivalId;
+                    const playerName =
+                      event.playerId != null
+                        ? playerMap.get(event.playerId)?.nombre
+                        : undefined;
+
+                    return (
+                      <li key={event.id} className="relative pl-6">
+                        <span
+                          className={cn(
+                            "absolute left-[-10px] top-2 h-3 w-3 rounded-full border",
+                            descriptor.dotClass,
+                            isOurEvent
+                              ? "ring-2 ring-emerald-300"
+                              : isRivalEvent
+                              ? "ring-2 ring-red-300"
+                              : "ring-2 ring-slate-200"
+                          )}
+                          aria-hidden
+                        />
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-2 text-sm font-semibold">
+                              <span
+                                className={cn(
+                                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                                  descriptor.pillClass
+                                )}
+                              >
+                                <Icon className="h-3.5 w-3.5" />
+                                {descriptor.label}
+                              </span>
+                              {playerName ? (
+                                <span className="text-sm font-medium text-foreground">
+                                  {playerName}
+                                </span>
+                              ) : null}
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                              {isOurEvent ? (
+                                <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-700">
+                                  Nuestro equipo
+                                </Badge>
+                              ) : isRivalEvent ? (
+                                <Badge variant="secondary" className="bg-red-500/10 text-red-700">
+                                  Rival
+                                </Badge>
+                              ) : null}
+                              {!hasCustomLabel ? (
+                                <span className="capitalize">{event.type}</span>
+                              ) : null}
+                            </div>
+                          </div>
+                          <Badge variant="outline" className="text-xs font-semibold">
+                            {event.minute}&apos;
+                          </Badge>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="pb-4">
+              <CardTitle>Convocatoria</CardTitle>
+              <CardDescription>
+                Distribución de la plantilla entre titulares, suplentes y desconvocados.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <div className="flex items-center justify-between text-sm font-semibold">
+                  <span>Titulares</span>
+                  <Badge variant="outline">{starters.length}</Badge>
+                </div>
+                {renderPlayerList(starters, "Sin titulares asignados")}
+              </div>
+              <div>
+                <div className="flex items-center justify-between text-sm font-semibold">
+                  <span>Suplentes</span>
+                  <Badge variant="outline">{bench.length}</Badge>
+                </div>
+                {renderPlayerList(bench, "Sin suplentes seleccionados")}
+              </div>
+              <div>
+                <div className="flex items-center justify-between text-sm font-semibold">
+                  <span>Desconvocados</span>
+                  <Badge variant="outline">{unavailable.length}</Badge>
+                </div>
+                {renderPlayerList(unavailable, "Todos los jugadores fueron convocados")}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-4">
+              <CardTitle>Minutos jugados</CardTitle>
+              <CardDescription>
+                Seguimiento del tiempo en cancha de los jugadores utilizados.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {minutesData.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  Todavía no hay minutos registrados en este encuentro.
+                </p>
+              ) : (
+                minutesSorted.map((entry) => {
+                  const player = playerMap.get(entry.id);
+                  if (!player) return null;
+                  const percentage = Math.min(100, Math.round((entry.minutes / maxMinutes) * 100));
+                  return (
+                    <div key={entry.id} className="space-y-2">
+                      <div className="flex items-center justify-between text-sm font-medium">
+                        <span>{player.nombre}</span>
+                        <span>{entry.minutes}&apos;</span>
+                      </div>
+                      <div className="h-2 w-full rounded-full bg-muted">
+                        <div
+                          className="h-full rounded-full bg-primary"
+                          style={{ width: `${percentage}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle>Valoraciones</CardTitle>
+          <CardDescription>
+            Accede rápidamente a la ficha de valoración de cada jugador con minutos.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {minutesData.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Una vez que registres minutos podrás valorar el rendimiento individual.
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {minutesSorted.map((entry) => {
+                const player = playerMap.get(entry.id);
+                if (!player) return null;
+                return (
                   <a
-                    className="text-blue-600 underline"
-                    href={`/dashboard/valoraciones?jugador=${l.playerId}`}
+                    key={entry.id}
+                    href={`/dashboard/valoraciones?jugador=${entry.id}`}
+                    className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors hover:bg-muted"
                   >
-                    Valorar a {p?.nombre}
+                    <span className="font-medium">{player.nombre}</span>
+                    <Badge variant="secondary" className="bg-primary/10 text-primary">
+                      {entry.minutes}&apos;
+                    </Badge>
                   </a>
-                </li>
-              );
-            })}
-        </ul>
-      </section>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -25,6 +25,10 @@ interface Player {
 interface Props {
   match: Match;
   players: Player[];
+  homeTeamName: string;
+  awayTeamName: string;
+  homeTeamColor: string;
+  awayTeamColor: string;
 }
 
 interface EventDescriptor {
@@ -68,7 +72,30 @@ const DEFAULT_EVENT: EventDescriptor = {
   pillClass: "bg-muted text-muted-foreground",
 };
 
-export default function MatchSummary({ match, players }: Props) {
+const COMPETITION_LABELS: Record<string, string> = {
+  liga: "Liga",
+  playoff: "Play Off",
+  copa: "Copa",
+  amistoso: "Amistoso",
+};
+
+function getContrastColor(hex: string) {
+  const c = hex.replace("#", "");
+  const r = parseInt(c.substring(0, 2), 16);
+  const g = parseInt(c.substring(2, 4), 16);
+  const b = parseInt(c.substring(4, 6), 16);
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq >= 128 ? "#0f172a" : "#fff";
+}
+
+export default function MatchSummary({
+  match,
+  players,
+  homeTeamName,
+  awayTeamName,
+  homeTeamColor,
+  awayTeamColor,
+}: Props) {
   const playerMap = new Map(players.map((p) => [p.id, p]));
   const starters = match.lineup
     .filter((slot) => slot.role === "field" && slot.playerId)
@@ -101,14 +128,14 @@ export default function MatchSummary({ match, players }: Props) {
 
   function renderPlayerList(items: Player[], emptyMessage: string) {
     if (!items.length) {
-      return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+      return <p className="text-sm text-slate-400">{emptyMessage}</p>;
     }
     const sorted = [...items].sort((a, b) => a.nombre.localeCompare(b.nombre));
     return (
-      <ul className="mt-2 grid gap-1 text-sm text-muted-foreground">
+      <ul className="mt-2 grid gap-1 text-sm text-slate-200/90">
         {sorted.map((player) => (
           <li key={player.id} className="flex items-center gap-2">
-            <span className="h-2 w-2 rounded-full bg-primary/60" aria-hidden />
+            <span className="h-2 w-2 rounded-full bg-primary/70" aria-hidden />
             <span>{player.nombre}</span>
           </li>
         ))}
@@ -116,201 +143,323 @@ export default function MatchSummary({ match, players }: Props) {
     );
   }
 
-  return (
-    <div className="p-4 space-y-6">
-      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
-        <Card className="overflow-hidden">
-          <CardHeader className="pb-4">
-            <CardTitle>Timeline del partido</CardTitle>
-            <CardDescription>
-              Resumen cronológico de los momentos clave del encuentro.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {timelineEvents.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                Aún no se registraron eventos para este partido.
-              </p>
-            ) : (
-              <div className="relative pl-5">
-                <div className="absolute left-2 top-0 h-full w-px bg-border" aria-hidden />
-                <ul className="space-y-6">
-                  {timelineEvents.map((event) => {
-                    const descriptor = EVENT_CONFIG[event.type] ?? DEFAULT_EVENT;
-                    const hasCustomLabel = Boolean(EVENT_CONFIG[event.type]);
-                    const Icon = descriptor.icon;
-                    const isOurEvent =
-                      event.teamId === match.teamId ||
-                      (event.playerId != null &&
-                        match.lineup.some((slot) => slot.playerId === event.playerId));
-                    const isRivalEvent = event.rivalId === match.rivalId;
-                    const playerName =
-                      event.playerId != null
-                        ? playerMap.get(event.playerId)?.nombre
-                        : undefined;
+  const ourGoals = match.events.filter(
+    (event) => event.type === "gol" && event.teamId === match.teamId
+  ).length;
+  const rivalGoals = match.events.filter(
+    (event) => event.type === "gol" && event.rivalId === match.rivalId
+  ).length;
+  const homeGoals = match.isHome ? ourGoals : rivalGoals;
+  const awayGoals = match.isHome ? rivalGoals : ourGoals;
+  const homeLabel = match.isHome ? "Nuestro equipo" : "Rival";
+  const awayLabel = match.isHome ? "Rival" : "Nuestro equipo";
+  const homeContrast = getContrastColor(homeTeamColor);
+  const awayContrast = getContrastColor(awayTeamColor);
+  const competitionLabel =
+    COMPETITION_LABELS[match.competition] ?? match.competition;
+  const kickoff = new Date(match.kickoff);
+  const formattedKickoff = new Intl.DateTimeFormat("es-ES", {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(kickoff);
 
-                    return (
-                      <li key={event.id} className="relative pl-6">
-                        <span
-                          className={cn(
-                            "absolute left-[-10px] top-2 h-3 w-3 rounded-full border",
-                            descriptor.dotClass,
-                            isOurEvent
-                              ? "ring-2 ring-emerald-300"
-                              : isRivalEvent
-                              ? "ring-2 ring-red-300"
-                              : "ring-2 ring-slate-200"
-                          )}
-                          aria-hidden
-                        />
-                        <div className="flex flex-wrap items-start justify-between gap-3">
-                          <div className="space-y-1">
-                            <div className="flex items-center gap-2 text-sm font-semibold">
-                              <span
-                                className={cn(
-                                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
-                                  descriptor.pillClass
-                                )}
-                              >
-                                <Icon className="h-3.5 w-3.5" />
-                                {descriptor.label}
-                              </span>
-                              {playerName ? (
-                                <span className="text-sm font-medium text-foreground">
-                                  {playerName}
-                                </span>
-                              ) : null}
+  let resultLabel = "Empate";
+  let resultClass = "border-slate-500/50 bg-slate-800/70 text-slate-200";
+  if (ourGoals > rivalGoals) {
+    resultLabel = "Victoria";
+    resultClass = "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+  } else if (ourGoals < rivalGoals) {
+    resultLabel = "Derrota";
+    resultClass = "border-rose-500/40 bg-rose-500/10 text-rose-300";
+  }
+
+  return (
+    <div
+      className="flex min-h-screen w-full flex-col overflow-x-hidden bg-slate-950 text-slate-100"
+      style={{ minHeight: "100vh", minWidth: "100vw" }}
+    >
+      <section className="relative overflow-hidden px-4 pb-6 pt-8 sm:px-6 lg:px-10">
+        <div
+          className="absolute inset-0 -z-10 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900"
+          aria-hidden
+        />
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur">
+          <div className="flex flex-wrap items-center justify-between gap-6">
+            <div className="flex flex-1 flex-wrap items-center gap-6">
+              <div className="flex items-center gap-3">
+                <div
+                  className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
+                  style={{ backgroundColor: homeTeamColor, color: homeContrast }}
+                >
+                  {homeTeamName.slice(0, 2).toUpperCase()}
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-300">
+                    {homeLabel}
+                  </p>
+                  <p className="text-lg font-semibold text-white">
+                    {homeTeamName}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 text-4xl font-bold tabular-nums text-white sm:text-5xl">
+                <span>{homeGoals}</span>
+                <span className="text-slate-400">-</span>
+                <span>{awayGoals}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <div
+                  className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
+                  style={{ backgroundColor: awayTeamColor, color: awayContrast }}
+                >
+                  {awayTeamName.slice(0, 2).toUpperCase()}
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-300">
+                    {awayLabel}
+                  </p>
+                  <p className="text-lg font-semibold text-white">
+                    {awayTeamName}
+                  </p>
+                </div>
+              </div>
+            </div>
+            <Badge
+              variant="outline"
+              className={cn(
+                "border px-3 py-1 text-sm font-semibold uppercase tracking-wide",
+                resultClass
+              )}
+            >
+              {resultLabel}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-slate-200/90">
+            <div className="flex items-center gap-3">
+              <Badge variant="outline" className="border-white/20 bg-white/10 text-white">
+                {competitionLabel}
+              </Badge>
+              {match.matchday ? <span>Jornada {match.matchday}</span> : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-xs sm:text-sm">
+              <Clock3 className="h-4 w-4" />
+              <span>{formattedKickoff}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+      <main className="flex-1 overflow-hidden">
+        <div className="mx-auto flex h-full max-w-5xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
+          <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[2fr,1fr]">
+            <Card className="flex min-h-0 flex-col border-slate-800 bg-slate-900/60 text-slate-100">
+              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+                <CardTitle>Timeline del partido</CardTitle>
+                <CardDescription className="text-slate-400">
+                  Resumen cronológico de los momentos clave del encuentro.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="relative flex-1 overflow-auto pr-4">
+                {timelineEvents.length === 0 ? (
+                  <p className="text-sm text-slate-400">
+                    Aún no se registraron eventos para este partido.
+                  </p>
+                ) : (
+                  <div className="relative space-y-6 pb-6 pl-5">
+                    <div
+                      className="absolute left-2 top-0 h-full w-px bg-slate-700"
+                      aria-hidden
+                    />
+                    <ul className="space-y-6">
+                      {timelineEvents.map((event) => {
+                        const descriptor = EVENT_CONFIG[event.type] ?? DEFAULT_EVENT;
+                        const hasCustomLabel = Boolean(EVENT_CONFIG[event.type]);
+                        const Icon = descriptor.icon;
+                        const isOurEvent =
+                          event.teamId === match.teamId ||
+                          (event.playerId != null &&
+                            match.lineup.some((slot) => slot.playerId === event.playerId));
+                        const isRivalEvent = event.rivalId === match.rivalId;
+                        const playerName =
+                          event.playerId != null
+                            ? playerMap.get(event.playerId)?.nombre
+                            : undefined;
+
+                        return (
+                          <li key={event.id} className="relative pl-6">
+                            <span
+                              className={cn(
+                                "absolute left-[-10px] top-2 h-3 w-3 rounded-full border",
+                                descriptor.dotClass,
+                                isOurEvent
+                                  ? "ring-2 ring-emerald-400/70"
+                                  : isRivalEvent
+                                  ? "ring-2 ring-rose-400/70"
+                                  : "ring-2 ring-slate-500/60"
+                              )}
+                              aria-hidden
+                            />
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div className="space-y-1">
+                                <div className="flex items-center gap-2 text-sm font-semibold">
+                                  <span
+                                    className={cn(
+                                      "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                                      descriptor.pillClass
+                                    )}
+                                  >
+                                    <Icon className="h-3.5 w-3.5" />
+                                    {descriptor.label}
+                                  </span>
+                                  {playerName ? (
+                                    <span className="text-sm font-medium text-white">
+                                      {playerName}
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <div className="flex items-center gap-2 text-xs text-slate-400">
+                                  {isOurEvent ? (
+                                    <Badge className="bg-emerald-500/10 text-emerald-300">
+                                      Nuestro equipo
+                                    </Badge>
+                                  ) : isRivalEvent ? (
+                                    <Badge className="bg-rose-500/10 text-rose-300">
+                                      Rival
+                                    </Badge>
+                                  ) : null}
+                                  {!hasCustomLabel ? (
+                                    <span className="capitalize">{event.type}</span>
+                                  ) : null}
+                                </div>
+                              </div>
+                              <Badge variant="outline" className="border-slate-700/70 text-xs font-semibold text-white">
+                                {event.minute}&apos;
+                              </Badge>
                             </div>
-                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                              {isOurEvent ? (
-                                <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-700">
-                                  Nuestro equipo
-                                </Badge>
-                              ) : isRivalEvent ? (
-                                <Badge variant="secondary" className="bg-red-500/10 text-red-700">
-                                  Rival
-                                </Badge>
-                              ) : null}
-                              {!hasCustomLabel ? (
-                                <span className="capitalize">{event.type}</span>
-                              ) : null}
-                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            <div className="flex min-h-0 flex-col gap-6">
+              <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+                <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+                  <CardTitle>Convocatoria</CardTitle>
+                  <CardDescription className="text-slate-400">
+                    Distribución de la plantilla entre titulares, suplentes y desconvocados.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div>
+                    <div className="flex items-center justify-between text-sm font-semibold">
+                      <span>Titulares</span>
+                      <Badge variant="outline" className="border-slate-700/70 text-white">
+                        {starters.length}
+                      </Badge>
+                    </div>
+                    {renderPlayerList(starters, "Sin titulares asignados")}
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between text-sm font-semibold">
+                      <span>Suplentes</span>
+                      <Badge variant="outline" className="border-slate-700/70 text-white">
+                        {bench.length}
+                      </Badge>
+                    </div>
+                    {renderPlayerList(bench, "Sin suplentes seleccionados")}
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between text-sm font-semibold">
+                      <span>Desconvocados</span>
+                      <Badge variant="outline" className="border-slate-700/70 text-white">
+                        {unavailable.length}
+                      </Badge>
+                    </div>
+                    {renderPlayerList(
+                      unavailable,
+                      "Todos los jugadores fueron convocados"
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+              <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+                <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+                  <CardTitle>Minutos jugados</CardTitle>
+                  <CardDescription className="text-slate-400">
+                    Seguimiento del tiempo en cancha de los jugadores utilizados.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {minutesData.length === 0 ? (
+                    <p className="text-sm text-slate-400">
+                      Todavía no hay minutos registrados en este encuentro.
+                    </p>
+                  ) : (
+                    minutesSorted.map((entry) => {
+                      const player = playerMap.get(entry.id);
+                      if (!player) return null;
+                      const percentage = Math.min(
+                        100,
+                        Math.round((entry.minutes / maxMinutes) * 100)
+                      );
+                      return (
+                        <div key={entry.id} className="space-y-2">
+                          <div className="flex items-center justify-between text-sm font-medium">
+                            <span>{player.nombre}</span>
+                            <span>{entry.minutes}&apos;</span>
                           </div>
-                          <Badge variant="outline" className="text-xs font-semibold">
-                            {event.minute}&apos;
-                          </Badge>
+                          <div className="h-2 w-full rounded-full bg-slate-800">
+                            <div
+                              className="h-full rounded-full bg-primary"
+                              style={{ width: `${percentage}%` }}
+                            />
+                          </div>
                         </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-        <div className="space-y-6">
-          <Card>
-            <CardHeader className="pb-4">
-              <CardTitle>Convocatoria</CardTitle>
-              <CardDescription>
-                Distribución de la plantilla entre titulares, suplentes y desconvocados.
+                      );
+                    })
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+          <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+            <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+              <CardTitle>Valoraciones</CardTitle>
+              <CardDescription className="text-slate-400">
+                Accede rápidamente a la ficha de valoración de cada jugador con minutos.
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <div className="flex items-center justify-between text-sm font-semibold">
-                  <span>Titulares</span>
-                  <Badge variant="outline">{starters.length}</Badge>
-                </div>
-                {renderPlayerList(starters, "Sin titulares asignados")}
-              </div>
-              <div>
-                <div className="flex items-center justify-between text-sm font-semibold">
-                  <span>Suplentes</span>
-                  <Badge variant="outline">{bench.length}</Badge>
-                </div>
-                {renderPlayerList(bench, "Sin suplentes seleccionados")}
-              </div>
-              <div>
-                <div className="flex items-center justify-between text-sm font-semibold">
-                  <span>Desconvocados</span>
-                  <Badge variant="outline">{unavailable.length}</Badge>
-                </div>
-                {renderPlayerList(unavailable, "Todos los jugadores fueron convocados")}
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="pb-4">
-              <CardTitle>Minutos jugados</CardTitle>
-              <CardDescription>
-                Seguimiento del tiempo en cancha de los jugadores utilizados.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent>
               {minutesData.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  Todavía no hay minutos registrados en este encuentro.
+                <p className="text-sm text-slate-400">
+                  Una vez que registres minutos podrás valorar el rendimiento individual.
                 </p>
               ) : (
-                minutesSorted.map((entry) => {
-                  const player = playerMap.get(entry.id);
-                  if (!player) return null;
-                  const percentage = Math.min(100, Math.round((entry.minutes / maxMinutes) * 100));
-                  return (
-                    <div key={entry.id} className="space-y-2">
-                      <div className="flex items-center justify-between text-sm font-medium">
-                        <span>{player.nombre}</span>
-                        <span>{entry.minutes}&apos;</span>
-                      </div>
-                      <div className="h-2 w-full rounded-full bg-muted">
-                        <div
-                          className="h-full rounded-full bg-primary"
-                          style={{ width: `${percentage}%` }}
-                        />
-                      </div>
-                    </div>
-                  );
-                })
+                <div className="flex flex-wrap gap-2">
+                  {minutesSorted.map((entry) => {
+                    const player = playerMap.get(entry.id);
+                    if (!player) return null;
+                    return (
+                      <a
+                        key={entry.id}
+                        href={`/dashboard/valoraciones?jugador=${entry.id}`}
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900 px-3 py-1 text-sm transition-colors hover:border-primary/60 hover:bg-primary/10"
+                      >
+                        <span className="font-medium">{player.nombre}</span>
+                        <Badge className="bg-primary/10 text-primary">
+                          {entry.minutes}&apos;
+                        </Badge>
+                      </a>
+                    );
+                  })}
+                </div>
               )}
             </CardContent>
           </Card>
         </div>
-      </div>
-      <Card>
-        <CardHeader className="pb-4">
-          <CardTitle>Valoraciones</CardTitle>
-          <CardDescription>
-            Accede rápidamente a la ficha de valoración de cada jugador con minutos.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {minutesData.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              Una vez que registres minutos podrás valorar el rendimiento individual.
-            </p>
-          ) : (
-            <div className="flex flex-wrap gap-2">
-              {minutesSorted.map((entry) => {
-                const player = playerMap.get(entry.id);
-                if (!player) return null;
-                return (
-                  <a
-                    key={entry.id}
-                    href={`/dashboard/valoraciones?jugador=${entry.id}`}
-                    className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors hover:bg-muted"
-                  >
-                    <span className="font-medium">{player.nombre}</span>
-                    <Badge variant="secondary" className="bg-primary/10 text-primary">
-                      {entry.minutes}&apos;
-                    </Badge>
-                  </a>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      </main>
     </div>
   );
 }

--- a/src/app/dashboard/partidos/[id]/page.tsx
+++ b/src/app/dashboard/partidos/[id]/page.tsx
@@ -63,7 +63,14 @@ export default async function MatchPage({ params }: MatchPageProps) {
   }
 
   return match.finished ? (
-    <MatchSummary match={match} players={allPlayers} />
+    <MatchSummary
+      match={match}
+      players={allPlayers}
+      homeTeamName={homeTeamName ?? "Local"}
+      awayTeamName={awayTeamName ?? "Rival"}
+      homeTeamColor={homeTeamColor ?? "#dc2626"}
+      awayTeamColor={awayTeamColor ?? "#1d4ed8"}
+    />
   ) : (
     <MatchDetail
       match={match}

--- a/src/app/dashboard/partidos/[id]/page.tsx
+++ b/src/app/dashboard/partidos/[id]/page.tsx
@@ -3,6 +3,7 @@ import { jugadoresService, equiposService, rivalesService } from "@/lib/api/serv
 import MatchDetail from "./match-detail";
 import MatchSummary from "./match-summary";
 import type { PlayerSlot } from "@/types/match";
+import { revalidatePath } from "next/cache";
 
 export const dynamic = "force-dynamic";
 
@@ -41,7 +42,7 @@ export default async function MatchPage({ params }: MatchPageProps) {
     const teamId = teamIdRaw ? Number(teamIdRaw) : null;
     const rivalIdRaw = formData.get("rivalId");
     const rivalId = rivalIdRaw ? Number(rivalIdRaw) : null;
-    return await recordEvent({
+    const created = await recordEvent({
       matchId: id,
       minute,
       type,
@@ -50,16 +51,23 @@ export default async function MatchPage({ params }: MatchPageProps) {
       rivalId,
       data: null,
     });
+    revalidatePath(`/dashboard/partidos/${id}`);
+    revalidatePath("/dashboard/partidos");
+    return created;
   }
 
   async function deleteEventById(eventId: number) {
     "use server";
     await removeEvent(eventId);
+    revalidatePath(`/dashboard/partidos/${id}`);
+    revalidatePath("/dashboard/partidos");
   }
 
   async function saveLineupServer(lineup: PlayerSlot[], finished = false) {
     "use server";
     await updateLineup(id, lineup, opponentNotes, finished);
+    revalidatePath(`/dashboard/partidos/${id}`);
+    revalidatePath("/dashboard/partidos");
   }
 
   return match.finished ? (

--- a/src/app/dashboard/partidos/new/player-selector.tsx
+++ b/src/app/dashboard/partidos/new/player-selector.tsx
@@ -30,6 +30,10 @@ interface Props {
   textColor: string
   formations: FormationOption[]
   defaultFormation: string
+  initialStarters?: number[]
+  initialBench?: number[]
+  initialUnavailable?: number[]
+  initialFormation?: string
 }
 
 export default function PlayerSelector({
@@ -39,12 +43,16 @@ export default function PlayerSelector({
   textColor,
   formations,
   defaultFormation,
+  initialStarters = [],
+  initialBench = [],
+  initialUnavailable = [],
+  initialFormation,
 }: Props) {
   const [tab, setTab] = useState<'starters' | 'bench' | 'unavailable'>('starters')
-  const [starters, setStarters] = useState<number[]>([])
-  const [bench, setBench] = useState<number[]>([])
-  const [unavailable, setUnavailable] = useState<number[]>([])
-  const [formation, setFormation] = useState(defaultFormation)
+  const [starters, setStarters] = useState<number[]>(initialStarters)
+  const [bench, setBench] = useState<number[]>(initialBench)
+  const [unavailable, setUnavailable] = useState<number[]>(initialUnavailable)
+  const [formation, setFormation] = useState(initialFormation ?? defaultFormation)
   const [limitWarning, setLimitWarning] = useState<string | null>(null)
 
   const activeFormation = useMemo(

--- a/src/app/dashboard/partidos/new/player-selector.tsx
+++ b/src/app/dashboard/partidos/new/player-selector.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 interface Player {
   id: number
@@ -9,69 +17,164 @@ interface Player {
   dorsal: number | null
 }
 
+interface FormationOption {
+  value: string
+  label: string
+  positions: string[]
+}
+
 interface Props {
   players: Player[]
   teamColor: string
   goalkeeperColor: string
   textColor: string
+  formations: FormationOption[]
+  defaultFormation: string
 }
 
-export default function PlayerSelector({ players, teamColor, goalkeeperColor, textColor }: Props) {
-  const [tab, setTab] = useState<'starters' | 'bench'>('starters')
+export default function PlayerSelector({
+  players,
+  teamColor,
+  goalkeeperColor,
+  textColor,
+  formations,
+  defaultFormation,
+}: Props) {
+  const [tab, setTab] = useState<'starters' | 'bench' | 'unavailable'>('starters')
   const [starters, setStarters] = useState<number[]>([])
   const [bench, setBench] = useState<number[]>([])
+  const [unavailable, setUnavailable] = useState<number[]>([])
+  const [formation, setFormation] = useState(defaultFormation)
+  const [limitWarning, setLimitWarning] = useState<string | null>(null)
+
+  const activeFormation = useMemo(
+    () => formations.find(f => f.value === formation) ?? formations[0],
+    [formation, formations]
+  )
+  const maxStarters = activeFormation?.positions.length ?? 11
+
+  function enforceStarterLimit(nextStarters: number[]) {
+    if (nextStarters.length <= maxStarters) {
+      setStarters(nextStarters)
+      return
+    }
+    setLimitWarning(
+      `Solo puedes elegir ${maxStarters} titulares para la formación ${activeFormation?.label ?? formation}.`
+    )
+  }
 
   function toggle(id: number) {
+    setLimitWarning(null)
     if (tab === 'starters') {
-      setStarters(prev =>
-        prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+      enforceStarterLimit(
+        starters.includes(id)
+          ? starters.filter(p => p !== id)
+          : [...starters, id]
       )
       setBench(prev => prev.filter(p => p !== id))
+      setUnavailable(prev => prev.filter(p => p !== id))
     } else {
-      setBench(prev =>
-        prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
-      )
-      setStarters(prev => prev.filter(p => p !== id))
+      if (tab === 'bench') {
+        setBench(prev =>
+          prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+        )
+        setStarters(prev => prev.filter(p => p !== id))
+        setUnavailable(prev => prev.filter(p => p !== id))
+      } else {
+        setUnavailable(prev =>
+          prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+        )
+        setStarters(prev => prev.filter(p => p !== id))
+        setBench(prev => prev.filter(p => p !== id))
+      }
     }
   }
 
   const cardHighlight = (id: number) => {
     const isStarter = starters.includes(id)
     const isBench = bench.includes(id)
-    if (tab === 'starters') {
-      if (isStarter) return 'ring-2 ring-primary'
-      if (isBench) return 'opacity-40'
-    } else {
-      if (isBench) return 'ring-2 ring-primary'
-      if (isStarter) return 'opacity-40'
-    }
+    const isUnavailable = unavailable.includes(id)
+    if (isStarter) return 'ring-2 ring-emerald-500'
+    if (isBench) return 'ring-2 ring-sky-500'
+    if (isUnavailable) return 'ring-2 ring-muted'
+    if (tab === 'starters' && (isBench || isUnavailable)) return 'opacity-40'
+    if (tab === 'bench' && (isStarter || isUnavailable)) return 'opacity-40'
+    if (tab === 'unavailable' && (isStarter || isBench)) return 'opacity-40'
     return ''
   }
 
   return (
-    <div>
-      <div className="mb-4 flex gap-2">
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div>
+          <p className="text-sm font-medium">Formación</p>
+          <p className="text-xs text-muted-foreground">
+            Titulares seleccionados: {starters.length}/{maxStarters}
+          </p>
+        </div>
+        <Select
+          value={formation}
+          onValueChange={value => {
+            setFormation(value)
+            const formationData = formations.find(f => f.value === value)
+            const limit = formationData?.positions.length ?? maxStarters
+            if (starters.length > limit) {
+              setStarters(prev => prev.slice(0, limit))
+            }
+            setLimitWarning(null)
+          }}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Selecciona formación" />
+          </SelectTrigger>
+          <SelectContent>
+            {formations.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {limitWarning ? (
+        <p className="text-xs text-destructive">{limitWarning}</p>
+      ) : null}
+      <div className="flex gap-2">
         <button
           type="button"
           onClick={() => setTab('starters')}
-          className={`px-3 py-1 rounded-full text-sm transition-colors ${
+          className={cn(
+            'px-3 py-1 rounded-full text-sm transition-colors',
             tab === 'starters'
               ? 'bg-primary text-primary-foreground'
               : 'bg-muted text-muted-foreground'
-          }`}
+          )}
         >
-          Titulares ({starters.length})
+          Titulares ({starters.length}/{maxStarters})
         </button>
         <button
           type="button"
           onClick={() => setTab('bench')}
-          className={`px-3 py-1 rounded-full text-sm transition-colors ${
+          className={cn(
+            'px-3 py-1 rounded-full text-sm transition-colors',
             tab === 'bench'
               ? 'bg-primary text-primary-foreground'
               : 'bg-muted text-muted-foreground'
-          }`}
+          )}
         >
           Suplentes ({bench.length})
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('unavailable')}
+          className={cn(
+            'px-3 py-1 rounded-full text-sm transition-colors',
+            tab === 'unavailable'
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-muted-foreground'
+          )}
+        >
+          Desconvocados ({unavailable.length})
         </button>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
@@ -81,9 +184,10 @@ export default function PlayerSelector({ players, teamColor, goalkeeperColor, te
             <div
               key={p.id}
               onClick={() => toggle(p.id)}
-              className={`border rounded-md p-2 flex flex-col items-center gap-2 cursor-pointer select-none ${cardHighlight(
-                p.id
-              )}`}
+              className={cn(
+                'border rounded-md p-2 flex flex-col items-center gap-2 cursor-pointer select-none transition-shadow hover:shadow-sm',
+                cardHighlight(p.id)
+              )}
             >
               <div
                 className="w-12 h-12 flex items-center justify-center rounded"
@@ -104,6 +208,10 @@ export default function PlayerSelector({ players, teamColor, goalkeeperColor, te
       {bench.map(id => (
         <input key={`b-${id}`} type="hidden" name="bench" value={id} />
       ))}
+      {unavailable.map(id => (
+        <input key={`u-${id}`} type="hidden" name="unavailable" value={id} />
+      ))}
+      <input type="hidden" name="formation" value={formation} />
     </div>
   )
 }

--- a/src/app/dashboard/partidos/new/player-selector.tsx
+++ b/src/app/dashboard/partidos/new/player-selector.tsx
@@ -98,6 +98,14 @@ export default function PlayerSelector({
     }
   }
 
+  function handleCardClick(id: number, isUnavailable: boolean) {
+    if (isUnavailable && tab !== 'unavailable') {
+      setLimitWarning('Este jugador está desconvocado. Cambia a la pestaña de desconvocados para modificarlo.')
+      return
+    }
+    toggle(id)
+  }
+
   const cardHighlight = (id: number) => {
     const isStarter = starters.includes(id)
     const isBench = bench.includes(id)
@@ -105,8 +113,8 @@ export default function PlayerSelector({
     if (isStarter) return 'ring-2 ring-emerald-500'
     if (isBench) return 'ring-2 ring-sky-500'
     if (isUnavailable) return 'ring-2 ring-muted'
-    if (tab === 'starters' && (isBench || isUnavailable)) return 'opacity-40'
-    if (tab === 'bench' && (isStarter || isUnavailable)) return 'opacity-40'
+    if (tab === 'starters' && isBench) return 'opacity-40'
+    if (tab === 'bench' && isStarter) return 'opacity-40'
     if (tab === 'unavailable' && (isStarter || isBench)) return 'opacity-40'
     return ''
   }
@@ -188,14 +196,21 @@ export default function PlayerSelector({
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
         {players.map(p => {
           const bg = p.posicion === 'Portero' ? goalkeeperColor : teamColor
+          const isUnavailable = unavailable.includes(p.id)
+          const disabled = isUnavailable && tab !== 'unavailable'
           return (
             <div
               key={p.id}
-              onClick={() => toggle(p.id)}
+              onClick={() => {
+                if (disabled) return
+                handleCardClick(p.id, isUnavailable)
+              }}
               className={cn(
-                'border rounded-md p-2 flex flex-col items-center gap-2 cursor-pointer select-none transition-shadow hover:shadow-sm',
+                'border rounded-md p-2 flex flex-col items-center gap-2 select-none transition-shadow hover:shadow-sm',
+                disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
                 cardHighlight(p.id)
               )}
+              aria-disabled={disabled}
             >
               <div
                 className="w-12 h-12 flex items-center justify-center rounded"

--- a/src/app/dashboard/partidos/partidos-list.tsx
+++ b/src/app/dashboard/partidos/partidos-list.tsx
@@ -110,9 +110,28 @@ export default function PartidosList({ matches, teamMap }: PartidosListProps) {
                   <TableCell>{rival}</TableCell>
                   <TableCell className={resultColor}>{result}</TableCell>
                   <TableCell className="text-right">
-                    <Button variant="ghost" size="sm" asChild>
-                      <Link href={`/dashboard/partidos/${match.id}`}>Ver</Link>
-                    </Button>
+                    <div className="flex items-center justify-end gap-2">
+                      {match.finished ? (
+                        <Button variant="ghost" size="sm" asChild>
+                          <Link href={`/dashboard/partidos/${match.id}`}>
+                            Resumen
+                          </Link>
+                        </Button>
+                      ) : (
+                        <>
+                          <Button variant="ghost" size="sm" asChild>
+                            <Link href={`/dashboard/partidos/${match.id}/editar`}>
+                              Editar
+                            </Link>
+                          </Button>
+                          <Button variant="secondary" size="sm" asChild>
+                            <Link href={`/dashboard/partidos/${match.id}`}>
+                              {match.events.length > 0 ? "Continuar" : "Iniciar"}
+                            </Link>
+                          </Button>
+                        </>
+                      )}
+                    </div>
                   </TableCell>
                 </TableRow>
               );

--- a/src/data/formations.ts
+++ b/src/data/formations.ts
@@ -1,0 +1,29 @@
+export interface FormationDefinition {
+  label: string
+  positions: string[]
+}
+
+export const FORMATIONS: Record<string, FormationDefinition> = {
+  '4-3-3': {
+    label: '4-3-3',
+    positions: ['GK', 'LB', 'LCB', 'RCB', 'RB', 'LCM', 'CM', 'RCM', 'LW', 'ST', 'RW'],
+  },
+  '4-4-2': {
+    label: '4-4-2',
+    positions: ['GK', 'LB', 'LCB', 'RCB', 'RB', 'LM', 'LCM', 'RCM', 'RM', 'LS', 'RS'],
+  },
+  '4-2-3-1': {
+    label: '4-2-3-1',
+    positions: ['GK', 'LB', 'LCB', 'RCB', 'RB', 'LDM', 'RDM', 'CAM', 'LW', 'ST', 'RW'],
+  },
+} as const
+
+export type FormationKey = keyof typeof FORMATIONS
+
+export const DEFAULT_FORMATION_KEY: FormationKey = '4-3-3'
+
+export const FORMATION_OPTIONS = Object.entries(FORMATIONS).map(([value, data]) => ({
+  value: value as FormationKey,
+  label: data.label,
+  positions: data.positions,
+}))

--- a/src/data/formations.ts
+++ b/src/data/formations.ts
@@ -12,6 +12,10 @@ export const FORMATIONS: Record<string, FormationDefinition> = {
     label: '4-4-2',
     positions: ['GK', 'LB', 'LCB', 'RCB', 'RB', 'LM', 'LCM', 'RCM', 'RM', 'LS', 'RS'],
   },
+  '3-5-2': {
+    label: '3-5-2',
+    positions: ['GK', 'LCB', 'CB', 'RCB', 'LM', 'LCM', 'CM', 'RCM', 'RM', 'LS', 'RS'],
+  },
   '4-2-3-1': {
     label: '4-2-3-1',
     positions: ['GK', 'LB', 'LCB', 'RCB', 'RB', 'LDM', 'RDM', 'CAM', 'LW', 'ST', 'RW'],

--- a/src/lib/api/matches.ts
+++ b/src/lib/api/matches.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from 'fs';
+import path from 'path';
 import { neon } from '@neondatabase/serverless';
 import type {
   Match,
@@ -7,7 +9,26 @@ import type {
   NewMatchEvent,
 } from '@/types/match';
 
-function getSql() {
+type SqlClient = ReturnType<typeof neon>;
+
+const projectDataDir = path.join(process.cwd(), 'src', 'data');
+const runtimeDataDir = path.join('/tmp', 'data');
+const MATCHES_FILE = 'matches.json';
+
+function toNumber(value: any, fallback = 0): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function toNullableNumber(value: any): number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getSql(): SqlClient | null {
   const connectionString =
     process.env['DATABASE_URL'] ||
     process.env['POSTGRES_URL'] ||
@@ -15,9 +36,154 @@ function getSql() {
     process.env['POSTGRES_URL_NON_POOLING'] ||
     process.env['NEON_DATABASE_URL'];
   if (!connectionString) {
-    throw new Error('Database connection not configured');
+    return null;
   }
   return neon(connectionString);
+}
+
+function sanitizeLineup(input: any): PlayerSlot[] {
+  if (!Array.isArray(input)) return [];
+  const lineup: PlayerSlot[] = [];
+  input.forEach((raw: any) => {
+    const playerId = toNullableNumber(raw?.playerId ?? raw?.player_id);
+    if (playerId == null) return;
+    const role =
+      raw?.role === 'bench' || raw?.role === 'unavailable' ? raw.role : 'field';
+    const number = toNullableNumber(raw?.number ?? raw?.dorsal) ?? undefined;
+    const minutes = Math.max(0, toNumber(raw?.minutes, 0));
+    const position =
+      typeof raw?.position === 'string' && raw.position.length
+        ? raw.position
+        : undefined;
+    lineup.push({
+      playerId,
+      number,
+      role,
+      position,
+      minutes,
+    });
+  });
+  return lineup;
+}
+
+function sanitizeEvent(raw: any): MatchEvent {
+  const teamIdRaw = raw?.teamId ?? raw?.equipoId ?? raw?.equipo_id;
+  const rivalIdRaw = raw?.rivalId ?? raw?.rival_id;
+  const playerIdRaw = raw?.playerId ?? raw?.jugadorId ?? raw?.jugador_id;
+  return {
+    id: toNumber(raw?.id, 0),
+    matchId: toNumber(raw?.matchId ?? raw?.match_id ?? raw?.partido_id, 0),
+    minute: Math.max(0, Math.round(toNumber(raw?.minute ?? raw?.minuto, 0))),
+    type: String(raw?.type ?? raw?.tipo ?? ''),
+    playerId: toNullableNumber(playerIdRaw),
+    teamId: toNullableNumber(teamIdRaw),
+    rivalId: toNullableNumber(rivalIdRaw),
+    data: raw?.data ?? null,
+  };
+}
+
+function sanitizeMatch(raw: any): Match {
+  const competition =
+    raw?.competition === 'playoff' ||
+    raw?.competition === 'copa' ||
+    raw?.competition === 'amistoso'
+      ? raw.competition
+      : 'liga';
+  const kickoff = raw?.kickoff ?? raw?.inicio ?? new Date().toISOString();
+  const matchdayRaw = raw?.matchday ?? raw?.jornada ?? null;
+  const matchdayNumber = Number(matchdayRaw);
+  const matchday =
+    matchdayRaw === null ||
+    matchdayRaw === undefined ||
+    matchdayRaw === '' ||
+    !Number.isFinite(matchdayNumber)
+      ? null
+      : matchdayNumber;
+  const isHomeRaw = raw?.isHome ?? raw?.is_home;
+  const condition = raw?.condition ?? raw?.condicion;
+  const isHome =
+    typeof isHomeRaw === 'boolean'
+      ? isHomeRaw
+      : condition
+      ? condition === 'local'
+      : isHomeRaw === undefined || isHomeRaw === null
+      ? false
+      : String(isHomeRaw).toLowerCase() === 'true';
+  return {
+    id: toNumber(raw?.id, 0),
+    teamId: toNumber(raw?.teamId ?? raw?.team_id ?? raw?.equipo_id, 0),
+    rivalId: toNumber(raw?.rivalId ?? raw?.rival_id, 0),
+    isHome,
+    kickoff: String(kickoff),
+    competition,
+    matchday,
+    lineup: sanitizeLineup(raw?.lineup ?? []),
+    events: Array.isArray(raw?.events)
+      ? raw.events.map((event: any) => sanitizeEvent(event))
+      : [],
+    opponentNotes: raw?.opponentNotes ?? raw?.notas_rival ?? null,
+    finished: Boolean(raw?.finished ?? raw?.finalizado ?? false),
+  };
+}
+
+function cloneEvent(event: MatchEvent): MatchEvent {
+  return {
+    ...event,
+    data:
+      event.data === null || event.data === undefined
+        ? null
+        : JSON.parse(JSON.stringify(event.data)),
+  };
+}
+
+function cloneMatch(match: Match): Match {
+  return {
+    ...match,
+    lineup: match.lineup.map((slot) => ({ ...slot })),
+    events: match.events.map((event) => cloneEvent(event)),
+    opponentNotes: match.opponentNotes ?? null,
+  };
+}
+
+async function readMatchesStore(): Promise<Match[]> {
+  const candidates = [runtimeDataDir, projectDataDir];
+  for (const dir of candidates) {
+    try {
+      const payload = await fs.readFile(path.join(dir, MATCHES_FILE), 'utf8');
+      const parsed = JSON.parse(payload);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => sanitizeMatch(item));
+      }
+    } catch {
+      // try next location
+    }
+  }
+  return [];
+}
+
+async function writeMatchesStore(matches: Match[]): Promise<void> {
+  const serialized = matches.map((match) => sanitizeMatch(match));
+  const content = JSON.stringify(serialized, null, 2);
+  try {
+    await fs.mkdir(runtimeDataDir, { recursive: true });
+    await fs.writeFile(path.join(runtimeDataDir, MATCHES_FILE), content);
+  } catch {
+    await fs.mkdir(projectDataDir, { recursive: true });
+    await fs.writeFile(path.join(projectDataDir, MATCHES_FILE), content);
+  }
+}
+
+function getNextMatchId(matches: Match[]): number {
+  return matches.reduce((max, match) => Math.max(max, match.id), 0) + 1;
+}
+
+function getNextEventId(matches: Match[]): number {
+  return (
+    matches.reduce((max, match) => {
+      const localMax = match.events.reduce((acc, event) => Math.max(acc, event.id), 0);
+      return Math.max(max, localMax);
+    }, 0) + 1
+  );
 }
 
 function mapMatch(row: any, events: MatchEvent[] = []): Match {
@@ -51,7 +217,8 @@ function mapEvent(row: any): MatchEvent {
 
 export async function listMatches(): Promise<Match[]> {
   const sql = getSql();
-  const rows = await sql`
+  if (sql) {
+    const rows = await sql`
     SELECT p.id,
            p.equipo_id AS "teamId",
            p.rival_id AS "rivalId",
@@ -72,17 +239,27 @@ export async function listMatches(): Promise<Match[]> {
     ORDER BY p.inicio DESC
   `;
 
-  return rows.map((row: any) =>
-    mapMatch(
-      { ...row, lineup: row.lineup ? row.lineup : [] },
-      (row.events || []).map((e: any) => mapEvent(e))
+    return rows.map((row: any) =>
+      mapMatch(
+        { ...row, lineup: row.lineup ? row.lineup : [] },
+        (row.events || []).map((e: any) => mapEvent(e))
+      )
+    );
+  }
+
+  const matches = await readMatchesStore();
+  return matches
+    .slice()
+    .sort(
+      (a, b) => new Date(b.kickoff).getTime() - new Date(a.kickoff).getTime()
     )
-  );
+    .map((match) => cloneMatch(match));
 }
 
 export async function getMatch(id: number): Promise<Match | null> {
   const sql = getSql();
-  const rows = await sql`
+  if (sql) {
+    const rows = await sql`
     SELECT p.id,
            p.equipo_id AS "teamId",
            p.rival_id AS "rivalId",
@@ -96,10 +273,10 @@ export async function getMatch(id: number): Promise<Match | null> {
     FROM partidos p
     WHERE p.id = ${id}
   `;
-  const row = rows[0];
-  if (!row) return null;
+    const row = rows[0];
+    if (!row) return null;
 
-  const events = await sql`
+    const events = await sql`
     SELECT id,
            partido_id AS "matchId",
            minuto AS "minute",
@@ -112,15 +289,21 @@ export async function getMatch(id: number): Promise<Match | null> {
     WHERE partido_id = ${id}
     ORDER BY minuto
   `;
-  return mapMatch(
-    { ...row, lineup: row.lineup ? row.lineup : [] },
-    events.map((e: any) => mapEvent(e))
-  );
+    return mapMatch(
+      { ...row, lineup: row.lineup ? row.lineup : [] },
+      events.map((e: any) => mapEvent(e))
+    );
+  }
+
+  const matches = await readMatchesStore();
+  const match = matches.find((item) => item.id === id);
+  return match ? cloneMatch(match) : null;
 }
 
 export async function createMatch(match: NewMatch): Promise<Match> {
   const sql = getSql();
-  const [row] = await sql`
+  if (sql) {
+    const [row] = await sql`
     INSERT INTO partidos (equipo_id, rival_id, condicion, inicio, competicion, jornada, alineacion, notas_rival)
     VALUES (
       ${match.teamId},
@@ -143,12 +326,26 @@ export async function createMatch(match: NewMatch): Promise<Match> {
               notas_rival AS "opponentNotes",
               finalizado AS finished
   `;
-  return mapMatch({ ...row, lineup: row.lineup ? row.lineup : [] }, []);
+    return mapMatch({ ...row, lineup: row.lineup ? row.lineup : [] }, []);
+  }
+
+  const matches = await readMatchesStore();
+  const id = getNextMatchId(matches);
+  const newMatch = sanitizeMatch({
+    ...match,
+    id,
+    events: match.events ?? [],
+    finished: false,
+  });
+  matches.push(newMatch);
+  await writeMatchesStore(matches);
+  return cloneMatch(newMatch);
 }
 
 export async function recordEvent(event: NewMatchEvent): Promise<MatchEvent> {
   const sql = getSql();
-  const [row] = await sql`
+  if (sql) {
+    const [row] = await sql`
     INSERT INTO eventos_partido (partido_id, minuto, tipo, jugador_id, equipo_id, rival_id, datos)
     VALUES (
       ${event.matchId},
@@ -168,12 +365,51 @@ export async function recordEvent(event: NewMatchEvent): Promise<MatchEvent> {
               rival_id AS "rivalId",
               datos AS data
   `;
-  return mapEvent(row);
+    return mapEvent(row);
+  }
+
+  const matches = await readMatchesStore();
+  const index = matches.findIndex((match) => match.id === event.matchId);
+  if (index === -1) {
+    throw new Error(`Match ${event.matchId} not found`);
+  }
+  const id = getNextEventId(matches);
+  const storedEvent = sanitizeEvent({
+    ...event,
+    id,
+    matchId: event.matchId,
+  });
+  const updatedMatch: Match = {
+    ...matches[index],
+    events: [...matches[index].events, storedEvent].sort(
+      (a, b) => a.minute - b.minute
+    ),
+  };
+  matches[index] = updatedMatch;
+  await writeMatchesStore(matches);
+  return cloneEvent(storedEvent);
 }
 
 export async function removeEvent(id: number): Promise<void> {
   const sql = getSql();
-  await sql`DELETE FROM eventos_partido WHERE id = ${id}`;
+  if (sql) {
+    await sql`DELETE FROM eventos_partido WHERE id = ${id}`;
+    return;
+  }
+
+  const matches = await readMatchesStore();
+  let updated = false;
+  const nextMatches = matches.map((match) => {
+    const remaining = match.events.filter((event) => event.id !== id);
+    if (remaining.length !== match.events.length) {
+      updated = true;
+      return { ...match, events: remaining };
+    }
+    return match;
+  });
+  if (updated) {
+    await writeMatchesStore(nextMatches);
+  }
 }
 
 export async function updateLineup(
@@ -183,7 +419,8 @@ export async function updateLineup(
   finished = false
 ): Promise<Match> {
   const sql = getSql();
-  const [row] = await sql`
+  if (sql) {
+    const [row] = await sql`
     UPDATE partidos
     SET alineacion = ${JSON.stringify(lineup)},
         notas_rival = ${opponentNotes},
@@ -201,7 +438,7 @@ export async function updateLineup(
               finalizado AS finished
   `;
 
-  const events = await sql`
+    const events = await sql`
     SELECT id,
            partido_id AS "matchId",
            minuto AS "minute",
@@ -215,8 +452,24 @@ export async function updateLineup(
     ORDER BY minuto
   `;
 
-  return mapMatch(
-    { ...row, lineup: row.lineup ? row.lineup : [] },
-    events.map((e: any) => mapEvent(e))
-  );
+    return mapMatch(
+      { ...row, lineup: row.lineup ? row.lineup : [] },
+      events.map((e: any) => mapEvent(e))
+    );
+  }
+
+  const matches = await readMatchesStore();
+  const index = matches.findIndex((match) => match.id === matchId);
+  if (index === -1) {
+    throw new Error(`Match ${matchId} not found`);
+  }
+  const updatedMatch: Match = sanitizeMatch({
+    ...matches[index],
+    lineup,
+    opponentNotes,
+    finished,
+  });
+  matches[index] = updatedMatch;
+  await writeMatchesStore(matches);
+  return cloneMatch(updatedMatch);
 }

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -5,9 +5,9 @@ export interface PlayerSlot {
    */
   number?: number;
   /**
-   * Indicates whether the player starts on the field or the bench.
+   * Indicates whether the player starts on the field, the bench or is out of the squad.
    */
-  role: 'field' | 'bench';
+  role: 'field' | 'bench' | 'unavailable';
   /** Shorthand position code (e.g. GK, LB, ST) used for visual layout. */
   position?: string;
   /** Minutes played by the player in this match. */


### PR DESCRIPTION
## Summary
- add a reusable formations catalogue and extend match slots to support unavailable players
- enhance the match creation flow with formation selection plus starter, bench and desconvocado assignments
- refresh the match summary with a timeline layout, convocatoria overview and improved minutes/valoraciones blocks
- allow match creation to use the first available team instead of a hard-coded ID 1

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6dcd128188320ba889a40c0e36481