### PR TITLE
Improve match summary readability and shareability

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -14,7 +14,7 @@ export default function DashboardLayout({
   const isMatch = pathname?.startsWith("/dashboard/partidos/");
 
   if (isMatch) {
-    return <div className="h-screen w-screen overflow-hidden">{children}</div>;
+    return <>{children}</>;
   }
 
   return (

--- a/src/app/dashboard/partidos/[id]/event-manager.tsx
+++ b/src/app/dashboard/partidos/[id]/event-manager.tsx
@@ -6,13 +6,6 @@ import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -23,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { MatchEvent } from "@/types/match";
+import { cn } from "@/lib/utils";
 
 interface PlayerOption {
   id: number;
@@ -212,222 +206,218 @@ export default function EventManager({
     : "Añadir evento";
 
   return (
-    <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-      <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-        <CardTitle>Gestionar eventos</CardTitle>
-        <CardDescription className="text-slate-400">
-          Ajusta el acta del partido añadiendo, editando o eliminando incidencias.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="space-y-1">
-            <p className="text-sm font-semibold text-slate-200">
-              {isEditing ? "Editando evento" : "Acta del partido"}
-            </p>
-            <p className="text-xs text-slate-400">
-              {isEditing
-                ? "Guarda los cambios o cancela para volver al listado."
-                : "Despliega el formulario solo cuando vayas a registrar un evento."}
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant={formOpen ? "ghost" : "outline"}
-            onClick={() => {
-              if (formOpen) {
-                resetForm(true);
-              } else {
-                resetForm();
-                setFormOpen(true);
-              }
-            }}
-            disabled={saving}
-          >
-            {toggleLabel}
-          </Button>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-slate-900">
+            {isEditing ? "Editando evento" : "Acta del partido"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {isEditing
+              ? "Guarda los cambios o cancela para volver al listado."
+              : "Despliega el formulario solo cuando vayas a registrar un evento."}
+          </p>
         </div>
-        {formOpen ? (
-          <form
-            className="grid gap-4 rounded-lg border border-slate-800/60 bg-slate-900/70 p-4"
-            onSubmit={handleSubmit}
-          >
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <div className="grid gap-1">
-                <Label htmlFor="event-minute">Minuto</Label>
-                <Input
-                  id="event-minute"
-                  type="number"
-                  min={0}
-                  max={130}
-                  value={minute}
-                  onChange={(e) => setMinute(e.target.value)}
-                />
-              </div>
-              <div className="grid gap-1">
-                <Label>Tipo</Label>
-                <Select
-                  value={type}
-                  onValueChange={(value) => {
-                    setType(value);
-                    if (value === "asistencia") {
-                      setTeamScope("ours");
-                    }
-                    if (value !== "asistencia" && teamScope === "rival") {
-                      setPlayerId("none");
-                    }
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecciona tipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(EVENT_LABELS).map(([value, label]) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid gap-1">
-                <Label>Equipo</Label>
-                <Select
-                  value={type === "asistencia" ? "ours" : teamScope}
-                  onValueChange={(value) => {
-                    const scoped = value as TeamScope;
-                    setTeamScope(scoped);
-                    if (scoped === "rival") {
-                      setPlayerId("none");
-                    }
-                  }}
-                  disabled={type === "asistencia"}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecciona equipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ours">Nuestro equipo</SelectItem>
-                    <SelectItem value="rival">Rival</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid gap-1">
-                <Label>Jugador</Label>
-                <Select
-                  value={playerId}
-                  onValueChange={(value) => setPlayerId(value)}
-                  disabled={type !== "asistencia" && teamScope === "rival"}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecciona jugador" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">Sin especificar</SelectItem>
-                    {players.map((player) => (
-                      <SelectItem key={player.id} value={String(player.id)}>
-                        {player.nombre}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+        <Button
+          type="button"
+          variant={formOpen ? "secondary" : "outline"}
+          onClick={() => {
+            if (formOpen) {
+              resetForm(true);
+            } else {
+              resetForm();
+              setFormOpen(true);
+            }
+          }}
+          disabled={saving}
+        >
+          {toggleLabel}
+        </Button>
+      </div>
+      {formOpen ? (
+        <form
+          className="grid gap-4 rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm"
+          onSubmit={handleSubmit}
+        >
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="grid gap-1">
+              <Label htmlFor="event-minute">Minuto</Label>
+              <Input
+                id="event-minute"
+                type="number"
+                min={0}
+                max={130}
+                value={minute}
+                onChange={(e) => setMinute(e.target.value)}
+              />
             </div>
-            {error ? <p className="text-sm text-destructive">{error}</p> : null}
-            <div className="flex flex-wrap items-center gap-2">
-              <Button type="submit" disabled={saving}>
-                {saving
-                  ? mode === "edit"
-                    ? "Guardando..."
-                    : "Creando..."
-                  : mode === "edit"
-                  ? "Guardar cambios"
-                  : "Añadir evento"}
+            <div className="grid gap-1">
+              <Label>Tipo</Label>
+              <Select
+                value={type}
+                onValueChange={(value) => {
+                  setType(value);
+                  if (value === "asistencia") {
+                    setTeamScope("ours");
+                  }
+                  if (value !== "asistencia" && teamScope === "rival") {
+                    setPlayerId("none");
+                  }
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(EVENT_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1">
+              <Label>Equipo</Label>
+              <Select
+                value={type === "asistencia" ? "ours" : teamScope}
+                onValueChange={(value) => {
+                  const scoped = value as TeamScope;
+                  setTeamScope(scoped);
+                  if (scoped === "rival") {
+                    setPlayerId("none");
+                  }
+                }}
+                disabled={type === "asistencia"}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona equipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ours">Nuestro equipo</SelectItem>
+                  <SelectItem value="rival">Rival</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1">
+              <Label>Jugador</Label>
+              <Select
+                value={playerId}
+                onValueChange={(value) => setPlayerId(value)}
+                disabled={type !== "asistencia" && teamScope === "rival"}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona jugador" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Sin especificar</SelectItem>
+                  {players.map((player) => (
+                    <SelectItem key={player.id} value={String(player.id)}>
+                      {player.nombre}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="submit" disabled={saving}>
+              {saving
+                ? mode === "edit"
+                  ? "Guardando..."
+                  : "Creando..."
+                : mode === "edit"
+                ? "Guardar cambios"
+                : "Añadir evento"}
+            </Button>
+            {mode === "edit" ? (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => resetForm(true)}
+                disabled={saving}
+              >
+                Cancelar edición
               </Button>
-              {mode === "edit" ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => resetForm(true)}
-                  disabled={saving}
-                >
-                  Cancelar edición
-                </Button>
-              ) : null}
-            </div>
-          </form>
-        ) : null}
-
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-slate-200">Eventos registrados</p>
-            <Badge variant="outline" className="border-slate-700/70 text-white">
-              {sortedEvents.length}
-            </Badge>
+            ) : null}
           </div>
-          {sortedEvents.length === 0 ? (
-            <p className="text-sm text-slate-400">
-              Aún no hay eventos guardados en este partido.
-            </p>
-          ) : (
-            <ul className="space-y-3">
-              {sortedEvents.map((event) => {
-                const label = EVENT_LABELS[event.type] ?? event.type;
-                const scope = resolveTeamScope(event);
-                const playerName =
-                  event.playerId != null
-                    ? playerMap.get(event.playerId)?.nombre
-                    : null;
-                const isDeleting = deletingId === event.id;
-                return (
-                  <li
-                    key={event.id}
-                    className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-slate-800 bg-slate-900/60 p-3"
-                  >
-                    <div className="space-y-1">
-                      <div className="flex flex-wrap items-center gap-2 text-sm font-semibold text-white">
-                        <span>{label}</span>
-                        <Badge
-                          variant="outline"
-                          className="border-slate-700/70 text-xs uppercase tracking-wide"
-                        >
-                          {scope === "ours" ? "Nuestro" : "Rival"}
-                        </Badge>
-                        <Badge variant="outline" className="border-slate-700/70 text-xs">
-                          {event.minute}&apos;
-                        </Badge>
-                      </div>
-                      {playerName ? (
-                        <p className="text-xs text-slate-300">{playerName}</p>
-                      ) : null}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={() => beginEdit(event)}
-                        disabled={saving || isDeleting}
-                      >
-                        Editar
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="destructive"
-                        onClick={() => handleDelete(event.id)}
-                        disabled={saving || isDeleting}
-                      >
-                        {isDeleting ? "Eliminando..." : "Eliminar"}
-                      </Button>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+        </form>
+      ) : null}
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-slate-900">Eventos registrados</p>
+          <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
+            {sortedEvents.length}
+          </Badge>
         </div>
-      </CardContent>
-    </Card>
+        {sortedEvents.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Aún no hay eventos guardados en este partido.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {sortedEvents.map((event) => {
+              const label = EVENT_LABELS[event.type] ?? event.type;
+              const scope = resolveTeamScope(event);
+              const playerName =
+                event.playerId != null
+                  ? playerMap.get(event.playerId)?.nombre
+                  : null;
+              const isDeleting = deletingId === event.id;
+              return (
+                <li
+                  key={event.id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-sm"
+                >
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 text-sm font-semibold text-slate-900">
+                      <span>{label}</span>
+                      <Badge
+                        className={cn(
+                          "text-xs uppercase tracking-wide",
+                          scope === "ours"
+                            ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                            : "border-rose-200 bg-rose-50 text-rose-700"
+                        )}
+                      >
+                        {scope === "ours" ? "Nuestro" : "Rival"}
+                      </Badge>
+                      <Badge className="border-slate-200 bg-slate-50 text-xs text-slate-700">
+                        {event.minute}&apos;
+                      </Badge>
+                    </div>
+                    {playerName ? (
+                      <p className="text-xs text-muted-foreground">{playerName}</p>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => beginEdit(event)}
+                      disabled={saving || isDeleting}
+                    >
+                      Editar
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => handleDelete(event.id)}
+                      disabled={saving || isDeleting}
+                    >
+                      {isDeleting ? "Eliminando..." : "Eliminar"}
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/dashboard/partidos/[id]/layout.tsx
+++ b/src/app/dashboard/partidos/[id]/layout.tsx
@@ -1,3 +1,3 @@
 export default function MatchLayout({ children }: { children: React.ReactNode }) {
-  return <div className="h-screen w-screen overflow-hidden">{children}</div>;
+  return <>{children}</>;
 }

--- a/src/app/dashboard/partidos/[id]/lineup-roster-editor.tsx
+++ b/src/app/dashboard/partidos/[id]/lineup-roster-editor.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { PlayerSlot } from "@/types/match";
+
+interface PlayerOption {
+  id: number;
+  nombre: string;
+  dorsal?: number | null;
+}
+
+interface LineupRosterEditorProps {
+  lineup: PlayerSlot[];
+  players: PlayerOption[];
+  onSave: (lineup: PlayerSlot[]) => Promise<void>;
+}
+
+interface EditableEntry {
+  playerId: number;
+  name: string;
+  role: PlayerSlot["role"];
+  number?: number;
+  minutes: number;
+  cleanSheet?: boolean;
+  goalsConceded?: number;
+  position?: string;
+}
+
+const ROLE_LABELS: Record<PlayerSlot["role"], string> = {
+  field: "Titular",
+  bench: "Suplente",
+  unavailable: "Desconvocado",
+};
+
+function buildEntries(
+  lineup: PlayerSlot[],
+  playerMap: Map<number, PlayerOption>
+): EditableEntry[] {
+  return lineup
+    .map((slot) => {
+      const player = playerMap.get(slot.playerId);
+      return {
+        playerId: slot.playerId,
+        name: player?.nombre ?? `Jugador ${slot.playerId}`,
+        role: slot.role,
+        number: slot.number ?? player?.dorsal ?? undefined,
+        minutes: slot.minutes ?? 0,
+        cleanSheet: slot.cleanSheet,
+        goalsConceded: slot.goalsConceded,
+        position: slot.position,
+      } satisfies EditableEntry;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export default function LineupRosterEditor({
+  lineup,
+  players,
+  onSave,
+}: LineupRosterEditorProps) {
+  const playerMap = useMemo(
+    () => new Map(players.map((player) => [player.id, player])),
+    [players]
+  );
+  const [open, setOpen] = useState(false);
+  const [entries, setEntries] = useState<EditableEntry[]>(() =>
+    buildEntries(lineup, playerMap)
+  );
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string>("");
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (open) {
+      setEntries(buildEntries(lineup, playerMap));
+      setSelectedPlayerId("");
+    }
+  }, [open, lineup, playerMap]);
+
+  const availablePlayers = useMemo(() => {
+    const taken = new Set(entries.map((entry) => entry.playerId));
+    return players
+      .filter((player) => !taken.has(player.id))
+      .sort((a, b) => {
+        const dorsalA = a.dorsal ?? Number.POSITIVE_INFINITY;
+        const dorsalB = b.dorsal ?? Number.POSITIVE_INFINITY;
+        if (dorsalA !== dorsalB) return dorsalA - dorsalB;
+        return a.nombre.localeCompare(b.nombre);
+      });
+  }, [entries, players]);
+
+  function updateEntry(playerId: number, patch: Partial<EditableEntry>) {
+    setEntries((current) =>
+      current.map((entry) =>
+        entry.playerId === playerId ? { ...entry, ...patch } : entry
+      )
+    );
+  }
+
+  function removeEntry(playerId: number) {
+    setEntries((current) => current.filter((entry) => entry.playerId !== playerId));
+  }
+
+  function addEntry() {
+    if (!selectedPlayerId) return;
+    const id = Number(selectedPlayerId);
+    if (!Number.isFinite(id)) return;
+    const player = playerMap.get(id);
+    if (!player) return;
+    setEntries((current) =>
+      [...current, {
+        playerId: player.id,
+        name: player.nombre,
+        role: "bench",
+        number: player.dorsal ?? undefined,
+        minutes: 0,
+        cleanSheet: false,
+        goalsConceded: 0,
+        position: undefined,
+      }].sort((a, b) => a.name.localeCompare(b.name))
+    );
+    setSelectedPlayerId("");
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    startTransition(async () => {
+      try {
+        const existingMap = new Map(lineup.map((slot) => [slot.playerId, slot]));
+        const payload: PlayerSlot[] = entries.map((entry) => {
+          const previous = existingMap.get(entry.playerId);
+          const baseMinutes = previous?.minutes ?? entry.minutes ?? 0;
+          const minutes = entry.role === "unavailable" ? 0 : Math.max(0, baseMinutes);
+          const cleanSheet =
+            entry.role === "unavailable"
+              ? false
+              : previous?.cleanSheet ?? entry.cleanSheet ?? false;
+          const goalsConceded =
+            entry.role === "unavailable"
+              ? 0
+              : previous?.goalsConceded ?? entry.goalsConceded ?? 0;
+          return {
+            playerId: entry.playerId,
+            role: entry.role,
+            number: previous?.number ?? entry.number,
+            position: previous?.position ?? entry.position,
+            minutes,
+            cleanSheet,
+            goalsConceded,
+          } satisfies PlayerSlot;
+        });
+
+        await onSave(payload);
+        toast.success("Convocatoria actualizada correctamente");
+        setOpen(false);
+      } catch (error) {
+        console.error("No se pudo guardar la convocatoria", error);
+        toast.error("No se pudieron guardar los cambios");
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          Editar convocatoria
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Gestionar titulares y suplentes</DialogTitle>
+          <DialogDescription>
+            Ajusta el rol de cada jugador en la convocatoria o incorpora nuevos miembros de la plantilla.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-3 rounded-md border border-slate-200 bg-slate-50 p-3">
+            <Label htmlFor="add-player" className="text-sm font-medium text-slate-700">
+              Añadir jugador a la lista
+            </Label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Select
+                value={selectedPlayerId}
+                onValueChange={setSelectedPlayerId}
+              >
+                <SelectTrigger id="add-player" className="sm:w-64">
+                  <SelectValue placeholder="Selecciona un jugador" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availablePlayers.length === 0 ? (
+                    <SelectItem value="" disabled>
+                      Todos los jugadores ya están en la lista
+                    </SelectItem>
+                  ) : (
+                    availablePlayers.map((player) => (
+                      <SelectItem key={player.id} value={String(player.id)}>
+                        {player.nombre}
+                        {player.dorsal ? ` · ${player.dorsal}` : ""}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+              <Button type="button" onClick={addEntry} disabled={!selectedPlayerId}>
+                Añadir
+              </Button>
+            </div>
+          </div>
+          <ScrollArea className="max-h-[55vh] pr-2">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Jugador</TableHead>
+                  <TableHead className="w-32 text-center">Rol</TableHead>
+                  <TableHead className="w-32 text-center">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-center text-sm text-muted-foreground">
+                      Añade jugadores para construir la convocatoria.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  entries.map((entry) => (
+                    <TableRow key={entry.playerId}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium text-slate-900">{entry.name}</span>
+                          {entry.number ? (
+                            <span className="text-xs text-muted-foreground">Dorsal {entry.number}</span>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <Select
+                          value={entry.role}
+                          onValueChange={(value) =>
+                            updateEntry(entry.playerId, { role: value as PlayerSlot["role"] })
+                          }
+                        >
+                          <SelectTrigger className="w-28">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {Object.entries(ROLE_LABELS).map(([value, label]) => (
+                              <SelectItem key={value} value={value}>
+                                {label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => removeEntry(entry.playerId)}
+                        >
+                          Quitar
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </ScrollArea>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isPending}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Guardando..." : "Guardar cambios"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/partidos/[id]/lineup-roster-editor.tsx
+++ b/src/app/dashboard/partidos/[id]/lineup-roster-editor.tsx
@@ -210,7 +210,7 @@ export default function LineupRosterEditor({
             </Label>
             <div className="flex flex-col gap-2 sm:flex-row">
               <Select
-                value={selectedPlayerId}
+                value={selectedPlayerId === "" ? undefined : selectedPlayerId}
                 onValueChange={setSelectedPlayerId}
               >
                 <SelectTrigger id="add-player" className="sm:w-64">
@@ -218,7 +218,7 @@ export default function LineupRosterEditor({
                 </SelectTrigger>
                 <SelectContent>
                   {availablePlayers.length === 0 ? (
-                    <SelectItem value="" disabled>
+                    <SelectItem value="all-assigned" disabled>
                       Todos los jugadores ya están en la lista
                     </SelectItem>
                   ) : (

--- a/src/app/dashboard/partidos/[id]/lineup-roster-editor.tsx
+++ b/src/app/dashboard/partidos/[id]/lineup-roster-editor.tsx
@@ -135,17 +135,18 @@ export default function LineupRosterEditor({
     if (!Number.isFinite(id)) return;
     const player = playerMap.get(id);
     if (!player) return;
+    const newEntry: EditableEntry = {
+      playerId: player.id,
+      name: player.nombre,
+      role: "bench",
+      number: player.dorsal ?? undefined,
+      minutes: 0,
+      cleanSheet: false,
+      goalsConceded: 0,
+      position: undefined,
+    };
     setEntries((current) =>
-      [...current, {
-        playerId: player.id,
-        name: player.nombre,
-        role: "bench",
-        number: player.dorsal ?? undefined,
-        minutes: 0,
-        cleanSheet: false,
-        goalsConceded: 0,
-        position: undefined,
-      }].sort((a, b) => a.name.localeCompare(b.name))
+      [...current, newEntry].sort((a, b) => a.name.localeCompare(b.name))
     );
     setSelectedPlayerId("");
   }

--- a/src/app/dashboard/partidos/[id]/match-admin-panel.tsx
+++ b/src/app/dashboard/partidos/[id]/match-admin-panel.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import type { Match } from "@/types/match";
+
+interface Option {
+  id: number;
+  nombre: string;
+}
+
+interface Props {
+  match: Match;
+  teams: Option[];
+  rivals: Option[];
+  onUpdate: (formData: FormData) => Promise<void>;
+  onDelete: () => Promise<void>;
+}
+
+function toDateTimeLocal(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60 * 1000);
+  return local.toISOString().slice(0, 16);
+}
+
+export default function MatchAdminPanel({
+  match,
+  teams,
+  rivals,
+  onUpdate,
+  onDelete,
+}: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [teamId, setTeamId] = useState<number>(match.teamId);
+  const [rivalId, setRivalId] = useState<number>(match.rivalId);
+  const [isHome, setIsHome] = useState<boolean>(match.isHome);
+  const [kickoff, setKickoff] = useState<string>(toDateTimeLocal(match.kickoff));
+  const [competition, setCompetition] = useState<Match["competition"]>(
+    match.competition
+  );
+  const [matchday, setMatchday] = useState<string>(
+    match.matchday != null ? String(match.matchday) : ""
+  );
+  const [opponentNotes, setOpponentNotes] = useState<string>(
+    match.opponentNotes ?? ""
+  );
+
+  const teamsOptions = useMemo(
+    () => teams.slice().sort((a, b) => a.nombre.localeCompare(b.nombre)),
+    [teams]
+  );
+  const rivalsOptions = useMemo(
+    () => rivals.slice().sort((a, b) => a.nombre.localeCompare(b.nombre)),
+    [rivals]
+  );
+
+  function handleSwapCondition() {
+    setIsHome((prev) => !prev);
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData();
+    formData.set("teamId", String(teamId));
+    formData.set("rivalId", String(rivalId));
+    formData.set("isHome", String(isHome));
+    formData.set("competition", competition);
+    if (kickoff) {
+      formData.set("kickoff", kickoff);
+    }
+    formData.set("matchday", matchday);
+    formData.set("opponentNotes", opponentNotes);
+
+    startTransition(async () => {
+      try {
+        await onUpdate(formData);
+        toast.success("Partido actualizado correctamente");
+      } catch (error) {
+        console.error("No se pudo actualizar el partido", error);
+        toast.error("No se pudieron guardar los cambios del partido");
+      }
+    });
+  }
+
+  function handleDelete() {
+    const confirmed = window.confirm(
+      "¿Seguro que quieres eliminar este partido? Esta acción no se puede deshacer."
+    );
+    if (!confirmed) return;
+    startTransition(async () => {
+      try {
+        await onDelete();
+      } catch (error) {
+        if (error && typeof error === "object" && "digest" in error) {
+          // NEXT_REDIRECT se lanza como excepción, no debemos tratarlo como error.
+          return;
+        }
+        console.error("No se pudo eliminar el partido", error);
+        toast.error("No se pudo eliminar el partido");
+      }
+    });
+  }
+
+  return (
+    <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+      <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+        <CardTitle>Administrar partido</CardTitle>
+        <CardDescription className="text-slate-400">
+          Corrige datos del encuentro o elimínalo en caso de duplicados.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <div className="grid gap-4">
+            <div className="grid gap-1">
+              <Label>Equipo propio</Label>
+              <Select
+                value={String(teamId)}
+                onValueChange={(value) => setTeamId(Number(value))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona equipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  {teamsOptions.map((team) => (
+                    <SelectItem key={team.id} value={String(team.id)}>
+                      {team.nombre}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1">
+              <Label>Rival</Label>
+              <Select
+                value={String(rivalId)}
+                onValueChange={(value) => setRivalId(Number(value))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona rival" />
+                </SelectTrigger>
+                <SelectContent>
+                  {rivalsOptions.map((rival) => (
+                    <SelectItem key={rival.id} value={String(rival.id)}>
+                      {rival.nombre}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+              <div>
+                <p className="text-sm font-medium text-white">Condición</p>
+                <p className="text-xs text-slate-400">
+                  Marca si jugamos como locales o visitantes.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-slate-400">Visitante</span>
+                <Switch
+                  checked={isHome}
+                  onCheckedChange={setIsHome}
+                  aria-label="Cambiar condición del partido"
+                />
+                <span className="text-xs text-slate-200 font-medium">Local</span>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleSwapCondition}
+              disabled={isPending}
+            >
+              Invertir local/visitante
+            </Button>
+            <div className="grid gap-1">
+              <Label htmlFor="match-kickoff">Fecha y hora</Label>
+              <Input
+                id="match-kickoff"
+                type="datetime-local"
+                value={kickoff}
+                onChange={(event) => setKickoff(event.target.value)}
+              />
+            </div>
+            <div className="grid gap-1">
+              <Label>Competición</Label>
+              <Select
+                value={competition}
+                onValueChange={(value) =>
+                  setCompetition(value as Match["competition"])
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecciona competición" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="liga">Liga</SelectItem>
+                  <SelectItem value="playoff">Play Off</SelectItem>
+                  <SelectItem value="copa">Copa</SelectItem>
+                  <SelectItem value="amistoso">Amistoso</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="matchday">Jornada</Label>
+              <Input
+                id="matchday"
+                type="number"
+                min={1}
+                value={matchday}
+                onChange={(event) => setMatchday(event.target.value)}
+                placeholder="Deja vacío si no aplica"
+              />
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="opponent-notes">Notas del rival</Label>
+              <Textarea
+                id="opponent-notes"
+                value={opponentNotes}
+                onChange={(event) => setOpponentNotes(event.target.value)}
+                placeholder="Observaciones sobre el rival o contexto"
+                rows={3}
+              />
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Guardando..." : "Guardar cambios"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setTeamId(match.teamId);
+                setRivalId(match.rivalId);
+                setIsHome(match.isHome);
+                setKickoff(toDateTimeLocal(match.kickoff));
+                setCompetition(match.competition);
+                setMatchday(match.matchday != null ? String(match.matchday) : "");
+                setOpponentNotes(match.opponentNotes ?? "");
+              }}
+              disabled={isPending}
+            >
+              Restablecer
+            </Button>
+          </div>
+        </form>
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-destructive">
+                Eliminar partido
+              </p>
+              <p className="text-xs text-destructive/70">
+                Borra el partido si es un duplicado o se creó por error.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isPending}
+            >
+              {isPending ? "Eliminando..." : "Eliminar partido"}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/partidos/[id]/match-admin-panel.tsx
+++ b/src/app/dashboard/partidos/[id]/match-admin-panel.tsx
@@ -4,13 +4,6 @@ import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -125,170 +118,169 @@ export default function MatchAdminPanel({
   }
 
   return (
-    <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-      <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-        <CardTitle>Administrar partido</CardTitle>
-        <CardDescription className="text-slate-400">
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h3 className="text-base font-semibold text-slate-900">Administrar partido</h3>
+        <p className="text-sm text-muted-foreground">
           Corrige datos del encuentro o elimínalo en caso de duplicados.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        <form className="grid gap-4" onSubmit={handleSubmit}>
-          <div className="grid gap-4">
-            <div className="grid gap-1">
-              <Label>Equipo propio</Label>
-              <Select
-                value={String(teamId)}
-                onValueChange={(value) => setTeamId(Number(value))}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Selecciona equipo" />
-                </SelectTrigger>
-                <SelectContent>
-                  {teamsOptions.map((team) => (
-                    <SelectItem key={team.id} value={String(team.id)}>
-                      {team.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="grid gap-1">
-              <Label>Rival</Label>
-              <Select
-                value={String(rivalId)}
-                onValueChange={(value) => setRivalId(Number(value))}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Selecciona rival" />
-                </SelectTrigger>
-                <SelectContent>
-                  {rivalsOptions.map((rival) => (
-                    <SelectItem key={rival.id} value={String(rival.id)}>
-                      {rival.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-              <div>
-                <p className="text-sm font-medium text-white">Condición</p>
-                <p className="text-xs text-slate-400">
-                  Marca si jugamos como locales o visitantes.
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-slate-400">Visitante</span>
-                <Switch
-                  checked={isHome}
-                  onCheckedChange={setIsHome}
-                  aria-label="Cambiar condición del partido"
-                />
-                <span className="text-xs text-slate-200 font-medium">Local</span>
-              </div>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleSwapCondition}
-              disabled={isPending}
+        </p>
+      </div>
+      <form
+        className="grid gap-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+        onSubmit={handleSubmit}
+      >
+        <div className="grid gap-4">
+          <div className="grid gap-1">
+            <Label>Equipo propio</Label>
+            <Select
+              value={String(teamId)}
+              onValueChange={(value) => setTeamId(Number(value))}
             >
-              Invertir local/visitante
-            </Button>
-            <div className="grid gap-1">
-              <Label htmlFor="match-kickoff">Fecha y hora</Label>
-              <Input
-                id="match-kickoff"
-                type="datetime-local"
-                value={kickoff}
-                onChange={(event) => setKickoff(event.target.value)}
-              />
-            </div>
-            <div className="grid gap-1">
-              <Label>Competición</Label>
-              <Select
-                value={competition}
-                onValueChange={(value) =>
-                  setCompetition(value as Match["competition"])
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Selecciona competición" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="liga">Liga</SelectItem>
-                  <SelectItem value="playoff">Play Off</SelectItem>
-                  <SelectItem value="copa">Copa</SelectItem>
-                  <SelectItem value="amistoso">Amistoso</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="grid gap-1">
-              <Label htmlFor="matchday">Jornada</Label>
-              <Input
-                id="matchday"
-                type="number"
-                min={1}
-                value={matchday}
-                onChange={(event) => setMatchday(event.target.value)}
-                placeholder="Deja vacío si no aplica"
-              />
-            </div>
-            <div className="grid gap-1">
-              <Label htmlFor="opponent-notes">Notas del rival</Label>
-              <Textarea
-                id="opponent-notes"
-                value={opponentNotes}
-                onChange={(event) => setOpponentNotes(event.target.value)}
-                placeholder="Observaciones sobre el rival o contexto"
-                rows={3}
-              />
-            </div>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecciona equipo" />
+              </SelectTrigger>
+              <SelectContent>
+                {teamsOptions.map((team) => (
+                  <SelectItem key={team.id} value={String(team.id)}>
+                    {team.nombre}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <Button type="submit" disabled={isPending}>
-              {isPending ? "Guardando..." : "Guardar cambios"}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                setTeamId(match.teamId);
-                setRivalId(match.rivalId);
-                setIsHome(match.isHome);
-                setKickoff(toDateTimeLocal(match.kickoff));
-                setCompetition(match.competition);
-                setMatchday(match.matchday != null ? String(match.matchday) : "");
-                setOpponentNotes(match.opponentNotes ?? "");
-              }}
-              disabled={isPending}
+          <div className="grid gap-1">
+            <Label>Rival</Label>
+            <Select
+              value={String(rivalId)}
+              onValueChange={(value) => setRivalId(Number(value))}
             >
-              Restablecer
-            </Button>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecciona rival" />
+              </SelectTrigger>
+              <SelectContent>
+                {rivalsOptions.map((rival) => (
+                  <SelectItem key={rival.id} value={String(rival.id)}>
+                    {rival.nombre}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </form>
-        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <div>
-              <p className="text-sm font-semibold text-destructive">
-                Eliminar partido
-              </p>
-              <p className="text-xs text-destructive/70">
-                Borra el partido si es un duplicado o se creó por error.
+              <p className="text-sm font-medium text-slate-900">Condición</p>
+              <p className="text-xs text-muted-foreground">
+                Marca si jugamos como locales o visitantes.
               </p>
             </div>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={handleDelete}
-              disabled={isPending}
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">Visitante</span>
+              <Switch
+                checked={isHome}
+                onCheckedChange={setIsHome}
+                aria-label="Cambiar condición del partido"
+              />
+              <span className="text-xs font-medium text-slate-900">Local</span>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleSwapCondition}
+            disabled={isPending}
+          >
+            Invertir local/visitante
+          </Button>
+          <div className="grid gap-1">
+            <Label htmlFor="match-kickoff">Fecha y hora</Label>
+            <Input
+              id="match-kickoff"
+              type="datetime-local"
+              value={kickoff}
+              onChange={(event) => setKickoff(event.target.value)}
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label>Competición</Label>
+            <Select
+              value={competition}
+              onValueChange={(value) =>
+                setCompetition(value as Match["competition"])
+              }
             >
-              {isPending ? "Eliminando..." : "Eliminar partido"}
-            </Button>
+              <SelectTrigger>
+                <SelectValue placeholder="Selecciona competición" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="liga">Liga</SelectItem>
+                <SelectItem value="playoff">Play Off</SelectItem>
+                <SelectItem value="copa">Copa</SelectItem>
+                <SelectItem value="amistoso">Amistoso</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="matchday">Jornada</Label>
+            <Input
+              id="matchday"
+              type="number"
+              min={1}
+              value={matchday}
+              onChange={(event) => setMatchday(event.target.value)}
+              placeholder="Deja vacío si no aplica"
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="opponent-notes">Notas del rival</Label>
+            <Textarea
+              id="opponent-notes"
+              value={opponentNotes}
+              onChange={(event) => setOpponentNotes(event.target.value)}
+              placeholder="Observaciones sobre el rival o contexto"
+              rows={3}
+            />
           </div>
         </div>
-      </CardContent>
-    </Card>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Guardando..." : "Guardar cambios"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setTeamId(match.teamId);
+              setRivalId(match.rivalId);
+              setIsHome(match.isHome);
+              setKickoff(toDateTimeLocal(match.kickoff));
+              setCompetition(match.competition);
+              setMatchday(match.matchday != null ? String(match.matchday) : "");
+              setOpponentNotes(match.opponentNotes ?? "");
+            }}
+            disabled={isPending}
+          >
+            Restablecer
+          </Button>
+        </div>
+      </form>
+      <div className="rounded-lg border border-rose-200 bg-rose-50 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-rose-700">Eliminar partido</p>
+            <p className="text-xs text-rose-600">
+              Borra el partido si es un duplicado o se creó por error.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isPending}
+          >
+            {isPending ? "Eliminando..." : "Eliminar partido"}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -213,6 +213,8 @@ export default function MatchSummary({
   ).length;
   const homeGoals = match.isHome ? ourGoals : rivalGoals;
   const awayGoals = match.isHome ? rivalGoals : ourGoals;
+  const ourTeamName = match.isHome ? homeTeamName : awayTeamName;
+  const rivalTeamName = match.isHome ? awayTeamName : homeTeamName;
   const homeLabel = match.isHome ? "Nuestro equipo" : "Rival";
   const awayLabel = match.isHome ? "Rival" : "Nuestro equipo";
   const homeContrast = getContrastColor(homeTeamColor);
@@ -224,15 +226,15 @@ export default function MatchSummary({
     dateStyle: "long",
     timeStyle: "short",
   }).format(kickoff);
-  const opponentName = (match.isHome ? awayTeamName : homeTeamName) ?? "el rival";
-  const locationSummary = match.isHome ? "como locales" : "como visitantes";
+  const conditionLabel = match.isHome ? "Local" : "Visitante";
+  const locationSummary = match.isHome ? "en casa" : "a domicilio";
 
-  const summaryText =
+  const summaryHeadline =
     ourGoals === rivalGoals
-      ? `Empatamos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`
+      ? `${ourTeamName} empató ${ourGoals}-${rivalGoals} ${locationSummary} frente a ${rivalTeamName}.`
       : ourGoals > rivalGoals
-      ? `Ganamos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`
-      : `Perdimos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`;
+      ? `${ourTeamName} ganó ${ourGoals}-${rivalGoals} ${locationSummary} frente a ${rivalTeamName}.`
+      : `${ourTeamName} perdió ${ourGoals}-${rivalGoals} ${locationSummary} frente a ${rivalTeamName}.`;
 
   let resultLabel = "Empate";
   let resultClass = "border-slate-200 bg-slate-100 text-slate-600";
@@ -255,71 +257,131 @@ export default function MatchSummary({
   }
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-b from-slate-50 via-white to-slate-100 text-slate-900">
+    <div className="min-h-screen w-full bg-white text-slate-900">
       <section className="px-4 pb-6 pt-8 sm:px-6 lg:px-10">
-        <div className="mx-auto w-full max-w-5xl space-y-6">
-          <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-xl backdrop-blur-sm">
-            <div className="flex flex-wrap items-center justify-between gap-6">
-              <div className="flex flex-1 flex-wrap items-center gap-6">
-                <div className="flex items-center gap-3">
-                  <div
-                    className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
-                    style={{ backgroundColor: homeTeamColor, color: homeContrast }}
-                  >
-                    {homeTeamName.slice(0, 2).toUpperCase()}
+        <div className="mx-auto w-full max-w-5xl">
+          <Card className="border border-slate-200 shadow-xl">
+            <CardHeader className="space-y-6">
+              <div className="flex flex-wrap items-center justify-between gap-6">
+                <div className="flex flex-1 flex-wrap items-center gap-6">
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow"
+                      style={{ backgroundColor: homeTeamColor, color: homeContrast }}
+                    >
+                      {homeTeamName.slice(0, 2).toUpperCase()}
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {homeLabel}
+                      </p>
+                      <p className="text-lg font-semibold text-slate-900">{homeTeamName}</p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
-                      {homeLabel}
-                    </p>
-                    <p className="text-lg font-semibold text-slate-900">{homeTeamName}</p>
+                  <div className="flex items-center gap-3 text-4xl font-bold tabular-nums text-slate-900 sm:text-5xl">
+                    <span>{homeGoals}</span>
+                    <span className="text-muted-foreground">-</span>
+                    <span>{awayGoals}</span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <div
+                      className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow"
+                      style={{ backgroundColor: awayTeamColor, color: awayContrast }}
+                    >
+                      {awayTeamName.slice(0, 2).toUpperCase()}
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {awayLabel}
+                      </p>
+                      <p className="text-lg font-semibold text-slate-900">{awayTeamName}</p>
+                    </div>
                   </div>
                 </div>
-                <div className="flex items-center gap-3 text-4xl font-bold tabular-nums text-slate-900 sm:text-5xl">
-                  <span>{homeGoals}</span>
-                  <span className="text-muted-foreground">-</span>
-                  <span>{awayGoals}</span>
-                </div>
-                <div className="flex items-center gap-3">
-                  <div
-                    className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
-                    style={{ backgroundColor: awayTeamColor, color: awayContrast }}
-                  >
-                    {awayTeamName.slice(0, 2).toUpperCase()}
-                  </div>
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
-                      {awayLabel}
-                    </p>
-                    <p className="text-lg font-semibold text-slate-900">{awayTeamName}</p>
-                  </div>
-                </div>
-              </div>
-              <Badge
-                variant="outline"
-                className={cn(
-                  "border px-3 py-1 text-sm font-semibold uppercase tracking-wide",
-                  resultClass
-                )}
-              >
-                {resultLabel}
-              </Badge>
-            </div>
-            <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-muted-foreground">
-              <div className="flex items-center gap-3">
-                <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
-                  {competitionLabel}
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "border px-3 py-1 text-sm font-semibold uppercase tracking-wide",
+                    resultClass
+                  )}
+                >
+                  {resultLabel}
                 </Badge>
-                {match.matchday ? (
-                  <span className="font-medium text-slate-900">Jornada {match.matchday}</span>
-                ) : null}
               </div>
-              <div className="flex items-center gap-2 text-xs sm:text-sm">
-                <Clock3 className="h-4 w-4 text-muted-foreground" />
-                <span>{formattedKickoff}</span>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+                <div className="space-y-4">
+                  <p className="text-base font-medium text-slate-900">{summaryHeadline}</p>
+                  <div className="flex flex-wrap items-center gap-2 text-xs sm:text-sm text-muted-foreground">
+                    <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
+                      {competitionLabel}
+                    </Badge>
+                    {match.matchday ? (
+                      <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
+                        Jornada {match.matchday}
+                      </Badge>
+                    ) : null}
+                    <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
+                      {conditionLabel}
+                    </Badge>
+                    <span className="inline-flex items-center gap-1">
+                      <Clock3 className="h-4 w-4" />
+                      {formattedKickoff}
+                    </span>
+                  </div>
+                  {match.opponentNotes ? (
+                    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                        Notas del partido
+                      </p>
+                      <p className="mt-1 text-sm text-slate-700">{match.opponentNotes}</p>
+                    </div>
+                  ) : null}
+                </div>
+                <div className="grid gap-3 text-sm text-slate-700">
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <h4 className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {ourTeamName}
+                    </h4>
+                    <dl className="mt-2 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <dt>Goles</dt>
+                        <dd className="font-semibold text-slate-900">{eventBreakdown.ours.goals}</dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas amarillas</dt>
+                        <dd className="font-semibold text-amber-600">{eventBreakdown.ours.yellow}</dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas rojas</dt>
+                        <dd className="font-semibold text-rose-600">{eventBreakdown.ours.red}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <h4 className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {rivalTeamName}
+                    </h4>
+                    <dl className="mt-2 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <dt>Goles</dt>
+                        <dd className="font-semibold text-slate-900">{eventBreakdown.rival.goals}</dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas amarillas</dt>
+                        <dd className="font-semibold text-amber-600">{eventBreakdown.rival.yellow}</dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas rojas</dt>
+                        <dd className="font-semibold text-rose-600">{eventBreakdown.rival.red}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
         </div>
       </section>
       <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
@@ -330,7 +392,7 @@ export default function MatchSummary({
               Repasa los momentos clave minuto a minuto justo debajo del marcador.
             </CardDescription>
           </CardHeader>
-          <CardContent className="relative pr-4">
+          <CardContent className="relative">
             {timelineEvents.length === 0 ? (
               <p className="text-sm text-muted-foreground">
                 Aún no se registraron eventos para este partido.
@@ -410,74 +472,6 @@ export default function MatchSummary({
         </Card>
         <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
           <div className="flex flex-col gap-6">
-            <Card>
-              <CardHeader className="space-y-2">
-                <CardTitle>Resumen del partido</CardTitle>
-                <CardDescription>{summaryText}</CardDescription>
-              </CardHeader>
-              <CardContent className="grid gap-6 md:grid-cols-2">
-                <div className="space-y-3 text-sm text-slate-700">
-                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-                    <span className="text-muted-foreground">Competición</span>
-                    <span className="font-semibold text-slate-900">{competitionLabel}</span>
-                  </div>
-                  {match.matchday ? (
-                    <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-                      <span className="text-muted-foreground">Jornada</span>
-                      <span className="font-semibold text-slate-900">{match.matchday}</span>
-                    </div>
-                  ) : null}
-                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-                    <span className="text-muted-foreground">Condición</span>
-                    <span className="font-semibold text-slate-900">
-                      {match.isHome ? "Local" : "Visitante"}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-                    <span className="text-muted-foreground">Fecha</span>
-                    <span className="font-semibold text-slate-900">{formattedKickoff}</span>
-                  </div>
-                </div>
-                <div className="grid gap-3 text-sm text-slate-700">
-                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-                    <h4 className="text-xs uppercase tracking-wide text-muted-foreground">
-                      Nuestro equipo
-                    </h4>
-                    <dl className="mt-2 space-y-2">
-                      <div className="flex items-center justify-between">
-                        <dt>Goles</dt>
-                        <dd className="font-semibold text-slate-900">{eventBreakdown.ours.goals}</dd>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <dt>Tarjetas amarillas</dt>
-                        <dd className="font-semibold text-amber-600">{eventBreakdown.ours.yellow}</dd>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <dt>Tarjetas rojas</dt>
-                        <dd className="font-semibold text-rose-600">{eventBreakdown.ours.red}</dd>
-                      </div>
-                    </dl>
-                  </div>
-                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-                    <h4 className="text-xs uppercase tracking-wide text-muted-foreground">Rival</h4>
-                    <dl className="mt-2 space-y-2">
-                      <div className="flex items-center justify-between">
-                        <dt>Goles</dt>
-                        <dd className="font-semibold text-slate-900">{eventBreakdown.rival.goals}</dd>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <dt>Tarjetas amarillas</dt>
-                        <dd className="font-semibold text-amber-600">{eventBreakdown.rival.yellow}</dd>
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <dt>Tarjetas rojas</dt>
-                        <dd className="font-semibold text-rose-600">{eventBreakdown.rival.red}</dd>
-                      </div>
-                    </dl>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
             <Card>
               <CardHeader className="space-y-4 sm:flex sm:items-center sm:justify-between sm:space-y-0">
                 <div className="space-y-2">

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -133,6 +133,26 @@ export default function MatchSummary({
 
   const timelineEvents = [...match.events].sort((a, b) => a.minute - b.minute);
 
+  const eventBreakdown = match.events.reduce(
+    (acc, event) => {
+      if (event.teamId === match.teamId) {
+        if (event.type === "gol") acc.ours.goals += 1;
+        if (event.type === "amarilla") acc.ours.yellow += 1;
+        if (event.type === "roja") acc.ours.red += 1;
+      }
+      if (event.rivalId === match.rivalId) {
+        if (event.type === "gol") acc.rival.goals += 1;
+        if (event.type === "amarilla") acc.rival.yellow += 1;
+        if (event.type === "roja") acc.rival.red += 1;
+      }
+      return acc;
+    },
+    {
+      ours: { goals: 0, yellow: 0, red: 0 },
+      rival: { goals: 0, yellow: 0, red: 0 },
+    }
+  );
+
   function renderPlayerList(items: Player[], emptyMessage: string) {
     if (!items.length) {
       return <p className="text-sm text-slate-400">{emptyMessage}</p>;
@@ -169,6 +189,15 @@ export default function MatchSummary({
     dateStyle: "long",
     timeStyle: "short",
   }).format(kickoff);
+  const opponentName = (match.isHome ? awayTeamName : homeTeamName) ?? "el rival";
+  const locationSummary = match.isHome ? "como locales" : "como visitantes";
+
+  const summaryText =
+    ourGoals === rivalGoals
+      ? `Empatamos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`
+      : ourGoals > rivalGoals
+      ? `Ganamos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`
+      : `Perdimos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`;
 
   let resultLabel = "Empate";
   let resultClass = "border-slate-500/50 bg-slate-800/70 text-slate-200";
@@ -255,17 +284,101 @@ export default function MatchSummary({
           </div>
         </div>
       </section>
-      <main className="flex-1 overflow-hidden">
-        <div className="mx-auto flex h-full max-w-5xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
-          <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[2fr,1fr]">
-            <Card className="flex min-h-0 flex-col border-slate-800 bg-slate-900/60 text-slate-100">
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
+          <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+            <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+              <CardTitle>Resumen del partido</CardTitle>
+              <CardDescription className="text-slate-300">
+                {summaryText}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-3 text-sm text-slate-200/90">
+                <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                  <span className="text-slate-400">Competición</span>
+                  <span className="font-semibold text-white">{competitionLabel}</span>
+                </div>
+                {match.matchday ? (
+                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                    <span className="text-slate-400">Jornada</span>
+                    <span className="font-semibold text-white">{match.matchday}</span>
+                  </div>
+                ) : null}
+                <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                  <span className="text-slate-400">Condición</span>
+                  <span className="font-semibold text-white">
+                    {match.isHome ? "Local" : "Visitante"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                  <span className="text-slate-400">Fecha</span>
+                  <span className="font-semibold text-white">{formattedKickoff}</span>
+                </div>
+              </div>
+              <div className="grid gap-3 text-sm text-slate-200/90">
+                <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
+                  <h4 className="text-xs uppercase tracking-wide text-slate-400">
+                    Nuestro equipo
+                  </h4>
+                  <dl className="mt-2 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <dt>Goles</dt>
+                      <dd className="font-semibold text-white">
+                        {eventBreakdown.ours.goals}
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt>Tarjetas amarillas</dt>
+                      <dd className="font-semibold text-amber-300">
+                        {eventBreakdown.ours.yellow}
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt>Tarjetas rojas</dt>
+                      <dd className="font-semibold text-rose-300">
+                        {eventBreakdown.ours.red}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+                <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
+                  <h4 className="text-xs uppercase tracking-wide text-slate-400">
+                    Rival
+                  </h4>
+                  <dl className="mt-2 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <dt>Goles</dt>
+                      <dd className="font-semibold text-white">
+                        {eventBreakdown.rival.goals}
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt>Tarjetas amarillas</dt>
+                      <dd className="font-semibold text-amber-300">
+                        {eventBreakdown.rival.yellow}
+                      </dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt>Tarjetas rojas</dt>
+                      <dd className="font-semibold text-rose-300">
+                        {eventBreakdown.rival.red}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
               <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
                 <CardTitle>Timeline del partido</CardTitle>
                 <CardDescription className="text-slate-400">
                   Resumen cronológico de los momentos clave del encuentro.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="relative flex-1 overflow-auto pr-4">
+              <CardContent className="relative pr-4">
                 {timelineEvents.length === 0 ? (
                   <p className="text-sm text-slate-400">
                     Aún no se registraron eventos para este partido.
@@ -350,7 +463,7 @@ export default function MatchSummary({
                 )}
               </CardContent>
             </Card>
-            <div className="flex min-h-0 flex-col gap-6">
+            <div className="flex flex-col gap-6">
               <EventManager
                 initialEvents={match.events}
                 players={players}

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -18,6 +18,7 @@ import type { Match, MatchEvent, PlayerSlot } from "@/types/match";
 import { revalidatePath } from "next/cache";
 import EventManager from "./event-manager";
 import MatchAdminPanel from "./match-admin-panel";
+import LineupRosterEditor from "./lineup-roster-editor";
 import MinutesEditor from "./minutes-editor";
 import type { LucideIcon } from "lucide-react";
 import { Clock3, Goal, Octagon, Sparkles, Square } from "lucide-react";
@@ -478,11 +479,18 @@ export default function MatchSummary({
               </CardContent>
             </Card>
             <Card>
-              <CardHeader className="space-y-2">
-                <CardTitle>Convocatoria</CardTitle>
-                <CardDescription>
-                  Distribución de la plantilla entre titulares, suplentes y desconvocados.
-                </CardDescription>
+              <CardHeader className="space-y-4 sm:flex sm:items-center sm:justify-between sm:space-y-0">
+                <div className="space-y-2">
+                  <CardTitle>Convocatoria</CardTitle>
+                  <CardDescription>
+                    Distribución de la plantilla entre titulares, suplentes y desconvocados.
+                  </CardDescription>
+                </div>
+                <LineupRosterEditor
+                  lineup={match.lineup}
+                  players={players}
+                  onSave={handleSaveLineup}
+                />
               </CardHeader>
               <CardContent className="space-y-4">
                 <div>

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -218,8 +218,8 @@ export default function MatchSummary({
   }
 
   return (
-    <div className="min-h-screen w-full overflow-x-hidden overflow-y-auto bg-slate-950 text-slate-100">
-      <section className="relative overflow-hidden px-4 pb-6 pt-8 sm:px-6 lg:px-10">
+    <div className="min-h-screen w-full bg-slate-950 text-slate-100">
+      <section className="relative px-4 pb-6 pt-8 sm:px-6 lg:px-10">
         <div
           className="absolute inset-0 -z-10 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900"
           aria-hidden

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -9,16 +9,16 @@ import {
 import { cn } from "@/lib/utils";
 import type { Match, MatchEvent } from "@/types/match";
 import EventManager from "./event-manager";
+import MatchAdminPanel from "./match-admin-panel";
 import type { LucideIcon } from "lucide-react";
-import {
-  Clock3,
-  Goal,
-  Octagon,
-  Sparkles,
-  Square,
-} from "lucide-react";
+import { Clock3, Goal, Octagon, Sparkles, Square } from "lucide-react";
 
 interface Player {
+  id: number;
+  nombre: string;
+}
+
+interface TeamOption {
   id: number;
   nombre: string;
 }
@@ -33,6 +33,10 @@ interface Props {
   addEvent: (formData: FormData) => Promise<MatchEvent>;
   updateEvent: (formData: FormData) => Promise<MatchEvent>;
   deleteEvent: (id: number) => Promise<void>;
+  teams: TeamOption[];
+  rivals: TeamOption[];
+  updateMatch: (formData: FormData) => Promise<void>;
+  deleteMatch: () => Promise<void>;
 }
 
 interface EventDescriptor {
@@ -102,6 +106,10 @@ export default function MatchSummary({
   addEvent,
   updateEvent,
   deleteEvent,
+  teams,
+  rivals,
+  updateMatch,
+  deleteMatch,
 }: Props) {
   const playerMap = new Map(players.map((p) => [p.id, p]));
   const starters = match.lineup
@@ -210,10 +218,7 @@ export default function MatchSummary({
   }
 
   return (
-    <div
-      className="flex min-h-screen w-full flex-col overflow-x-hidden bg-slate-950 text-slate-100"
-      style={{ minHeight: "100vh", minWidth: "100vw" }}
-    >
+    <div className="min-h-screen w-full overflow-x-hidden overflow-y-auto bg-slate-950 text-slate-100">
       <section className="relative overflow-hidden px-4 pb-6 pt-8 sm:px-6 lg:px-10">
         <div
           className="absolute inset-0 -z-10 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900"
@@ -284,309 +289,316 @@ export default function MatchSummary({
           </div>
         </div>
       </section>
-      <main className="flex-1 overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
-          <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-            <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-              <CardTitle>Resumen del partido</CardTitle>
-              <CardDescription className="text-slate-300">
-                {summaryText}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-6 md:grid-cols-2">
-              <div className="space-y-3 text-sm text-slate-200/90">
-                <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                  <span className="text-slate-400">Competición</span>
-                  <span className="font-semibold text-white">{competitionLabel}</span>
-                </div>
-                {match.matchday ? (
-                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                    <span className="text-slate-400">Jornada</span>
-                    <span className="font-semibold text-white">{match.matchday}</span>
-                  </div>
-                ) : null}
-                <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                  <span className="text-slate-400">Condición</span>
-                  <span className="font-semibold text-white">
-                    {match.isHome ? "Local" : "Visitante"}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                  <span className="text-slate-400">Fecha</span>
-                  <span className="font-semibold text-white">{formattedKickoff}</span>
-                </div>
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
+        <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+          <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+            <CardTitle>Timeline del partido</CardTitle>
+            <CardDescription className="text-slate-400">
+              Repasa los momentos clave minuto a minuto justo debajo del marcador.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="relative pr-4">
+            {timelineEvents.length === 0 ? (
+              <p className="text-sm text-slate-400">
+                Aún no se registraron eventos para este partido.
+              </p>
+            ) : (
+              <div className="relative space-y-6 pb-6 pl-5">
+                <div
+                  className="absolute left-2 top-0 h-full w-px bg-slate-700"
+                  aria-hidden
+                />
+                <ul className="space-y-6">
+                  {timelineEvents.map((event) => {
+                    const descriptor = EVENT_CONFIG[event.type] ?? DEFAULT_EVENT;
+                    const hasCustomLabel = Boolean(EVENT_CONFIG[event.type]);
+                    const Icon = descriptor.icon;
+                    const isOurEvent =
+                      event.teamId === match.teamId ||
+                      (event.playerId != null &&
+                        match.lineup.some((slot) => slot.playerId === event.playerId));
+                    const isRivalEvent = event.rivalId === match.rivalId;
+                    const playerName =
+                      event.playerId != null
+                        ? playerMap.get(event.playerId)?.nombre
+                        : undefined;
+
+                    return (
+                      <li key={event.id} className="relative pl-6">
+                        <span
+                          className={cn(
+                            "absolute left-[-10px] top-2 h-3 w-3 rounded-full border",
+                            descriptor.dotClass,
+                            isOurEvent
+                              ? "ring-2 ring-emerald-400/70"
+                              : isRivalEvent
+                              ? "ring-2 ring-rose-400/70"
+                              : "ring-2 ring-slate-500/60"
+                          )}
+                          aria-hidden
+                        />
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-2 text-sm font-semibold">
+                              <span
+                                className={cn(
+                                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                                  descriptor.pillClass
+                                )}
+                              >
+                                <Icon className="h-3.5 w-3.5" />
+                                {descriptor.label}
+                              </span>
+                              {playerName ? (
+                                <span className="text-sm font-medium text-white">
+                                  {playerName}
+                                </span>
+                              ) : null}
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-slate-400">
+                              {isOurEvent ? (
+                                <Badge className="bg-emerald-500/10 text-emerald-300">
+                                  Nuestro equipo
+                                </Badge>
+                              ) : isRivalEvent ? (
+                                <Badge className="bg-rose-500/10 text-rose-300">
+                                  Rival
+                                </Badge>
+                              ) : null}
+                              {!hasCustomLabel ? (
+                                <span className="capitalize">{event.type}</span>
+                              ) : null}
+                            </div>
+                          </div>
+                          <Badge variant="outline" className="border-slate-700/70 text-xs font-semibold text-white">
+                            {event.minute}&apos;
+                          </Badge>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
               </div>
-              <div className="grid gap-3 text-sm text-slate-200/90">
-                <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
-                  <h4 className="text-xs uppercase tracking-wide text-slate-400">
-                    Nuestro equipo
-                  </h4>
-                  <dl className="mt-2 space-y-2">
-                    <div className="flex items-center justify-between">
-                      <dt>Goles</dt>
-                      <dd className="font-semibold text-white">
-                        {eventBreakdown.ours.goals}
-                      </dd>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <dt>Tarjetas amarillas</dt>
-                      <dd className="font-semibold text-amber-300">
-                        {eventBreakdown.ours.yellow}
-                      </dd>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <dt>Tarjetas rojas</dt>
-                      <dd className="font-semibold text-rose-300">
-                        {eventBreakdown.ours.red}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-                <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
-                  <h4 className="text-xs uppercase tracking-wide text-slate-400">
-                    Rival
-                  </h4>
-                  <dl className="mt-2 space-y-2">
-                    <div className="flex items-center justify-between">
-                      <dt>Goles</dt>
-                      <dd className="font-semibold text-white">
-                        {eventBreakdown.rival.goals}
-                      </dd>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <dt>Tarjetas amarillas</dt>
-                      <dd className="font-semibold text-amber-300">
-                        {eventBreakdown.rival.yellow}
-                      </dd>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <dt>Tarjetas rojas</dt>
-                      <dd className="font-semibold text-rose-300">
-                        {eventBreakdown.rival.red}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-          <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+            )}
+          </CardContent>
+        </Card>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="flex flex-col gap-6">
             <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
               <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-                <CardTitle>Timeline del partido</CardTitle>
-                <CardDescription className="text-slate-400">
-                  Resumen cronológico de los momentos clave del encuentro.
+                <CardTitle>Resumen del partido</CardTitle>
+                <CardDescription className="text-slate-300">
+                  {summaryText}
                 </CardDescription>
               </CardHeader>
-              <CardContent className="relative pr-4">
-                {timelineEvents.length === 0 ? (
+              <CardContent className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-3 text-sm text-slate-200/90">
+                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                    <span className="text-slate-400">Competición</span>
+                    <span className="font-semibold text-white">{competitionLabel}</span>
+                  </div>
+                  {match.matchday ? (
+                    <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                      <span className="text-slate-400">Jornada</span>
+                      <span className="font-semibold text-white">{match.matchday}</span>
+                    </div>
+                  ) : null}
+                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                    <span className="text-slate-400">Condición</span>
+                    <span className="font-semibold text-white">
+                      {match.isHome ? "Local" : "Visitante"}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
+                    <span className="text-slate-400">Fecha</span>
+                    <span className="font-semibold text-white">{formattedKickoff}</span>
+                  </div>
+                </div>
+                <div className="grid gap-3 text-sm text-slate-200/90">
+                  <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
+                    <h4 className="text-xs uppercase tracking-wide text-slate-400">
+                      Nuestro equipo
+                    </h4>
+                    <dl className="mt-2 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <dt>Goles</dt>
+                        <dd className="font-semibold text-white">
+                          {eventBreakdown.ours.goals}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas amarillas</dt>
+                        <dd className="font-semibold text-amber-300">
+                          {eventBreakdown.ours.yellow}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas rojas</dt>
+                        <dd className="font-semibold text-rose-300">
+                          {eventBreakdown.ours.red}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+                  <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
+                    <h4 className="text-xs uppercase tracking-wide text-slate-400">
+                      Rival
+                    </h4>
+                    <dl className="mt-2 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <dt>Goles</dt>
+                        <dd className="font-semibold text-white">
+                          {eventBreakdown.rival.goals}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas amarillas</dt>
+                        <dd className="font-semibold text-amber-300">
+                          {eventBreakdown.rival.yellow}
+                        </dd>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <dt>Tarjetas rojas</dt>
+                        <dd className="font-semibold text-rose-300">
+                          {eventBreakdown.rival.red}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+                <CardTitle>Convocatoria</CardTitle>
+                <CardDescription className="text-slate-400">
+                  Distribución de la plantilla entre titulares, suplentes y desconvocados.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <div className="flex items-center justify-between text-sm font-semibold">
+                    <span>Titulares</span>
+                    <Badge variant="outline" className="border-slate-700/70 text-white">
+                      {starters.length}
+                    </Badge>
+                  </div>
+                  {renderPlayerList(starters, "Sin titulares asignados")}
+                </div>
+                <div>
+                  <div className="flex items-center justify-between text-sm font-semibold">
+                    <span>Suplentes</span>
+                    <Badge variant="outline" className="border-slate-700/70 text-white">
+                      {bench.length}
+                    </Badge>
+                  </div>
+                  {renderPlayerList(bench, "Sin suplentes seleccionados")}
+                </div>
+                <div>
+                  <div className="flex items-center justify-between text-sm font-semibold">
+                    <span>Desconvocados</span>
+                    <Badge variant="outline" className="border-slate-700/70 text-white">
+                      {unavailable.length}
+                    </Badge>
+                  </div>
+                  {renderPlayerList(
+                    unavailable,
+                    "Todos los jugadores fueron convocados"
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+                <CardTitle>Minutos jugados</CardTitle>
+                <CardDescription className="text-slate-400">
+                  Seguimiento del tiempo en cancha de los jugadores utilizados.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {minutesData.length === 0 ? (
                   <p className="text-sm text-slate-400">
-                    Aún no se registraron eventos para este partido.
+                    Todavía no hay minutos registrados en este encuentro.
                   </p>
                 ) : (
-                  <div className="relative space-y-6 pb-6 pl-5">
-                    <div
-                      className="absolute left-2 top-0 h-full w-px bg-slate-700"
-                      aria-hidden
-                    />
-                    <ul className="space-y-6">
-                      {timelineEvents.map((event) => {
-                        const descriptor = EVENT_CONFIG[event.type] ?? DEFAULT_EVENT;
-                        const hasCustomLabel = Boolean(EVENT_CONFIG[event.type]);
-                        const Icon = descriptor.icon;
-                        const isOurEvent =
-                          event.teamId === match.teamId ||
-                          (event.playerId != null &&
-                            match.lineup.some((slot) => slot.playerId === event.playerId));
-                        const isRivalEvent = event.rivalId === match.rivalId;
-                        const playerName =
-                          event.playerId != null
-                            ? playerMap.get(event.playerId)?.nombre
-                            : undefined;
-
-                        return (
-                          <li key={event.id} className="relative pl-6">
-                            <span
-                              className={cn(
-                                "absolute left-[-10px] top-2 h-3 w-3 rounded-full border",
-                                descriptor.dotClass,
-                                isOurEvent
-                                  ? "ring-2 ring-emerald-400/70"
-                                  : isRivalEvent
-                                  ? "ring-2 ring-rose-400/70"
-                                  : "ring-2 ring-slate-500/60"
-                              )}
-                              aria-hidden
-                            />
-                            <div className="flex flex-wrap items-start justify-between gap-3">
-                              <div className="space-y-1">
-                                <div className="flex items-center gap-2 text-sm font-semibold">
-                                  <span
-                                    className={cn(
-                                      "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
-                                      descriptor.pillClass
-                                    )}
-                                  >
-                                    <Icon className="h-3.5 w-3.5" />
-                                    {descriptor.label}
-                                  </span>
-                                  {playerName ? (
-                                    <span className="text-sm font-medium text-white">
-                                      {playerName}
-                                    </span>
-                                  ) : null}
-                                </div>
-                                <div className="flex items-center gap-2 text-xs text-slate-400">
-                                  {isOurEvent ? (
-                                    <Badge className="bg-emerald-500/10 text-emerald-300">
-                                      Nuestro equipo
-                                    </Badge>
-                                  ) : isRivalEvent ? (
-                                    <Badge className="bg-rose-500/10 text-rose-300">
-                                      Rival
-                                    </Badge>
-                                  ) : null}
-                                  {!hasCustomLabel ? (
-                                    <span className="capitalize">{event.type}</span>
-                                  ) : null}
-                                </div>
-                              </div>
-                              <Badge variant="outline" className="border-slate-700/70 text-xs font-semibold text-white">
-                                {event.minute}&apos;
-                              </Badge>
-                            </div>
-                          </li>
-                        );
-                      })}
-                    </ul>
+                  minutesSorted.map((entry) => {
+                    const player = playerMap.get(entry.id);
+                    if (!player) return null;
+                    const percentage = Math.min(
+                      100,
+                      Math.round((entry.minutes / maxMinutes) * 100)
+                    );
+                    return (
+                      <div key={entry.id} className="space-y-2">
+                        <div className="flex items-center justify-between text-sm font-medium">
+                          <span>{player.nombre}</span>
+                          <span>{entry.minutes}&apos;</span>
+                        </div>
+                        <div className="h-2 w-full rounded-full bg-slate-800">
+                          <div
+                            className="h-full rounded-full bg-primary"
+                            style={{ width: `${percentage}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </CardContent>
+            </Card>
+            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+                <CardTitle>Valoraciones</CardTitle>
+                <CardDescription className="text-slate-400">
+                  Accede rápidamente a la ficha de valoración de cada jugador con minutos.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {minutesData.length === 0 ? (
+                  <p className="text-sm text-slate-400">
+                    Una vez que registres minutos podrás valorar el rendimiento individual.
+                  </p>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {minutesSorted.map((entry) => {
+                      const player = playerMap.get(entry.id);
+                      if (!player) return null;
+                      return (
+                        <a
+                          key={entry.id}
+                          href={`/dashboard/valoraciones?jugador=${entry.id}`}
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900 px-3 py-1 text-sm transition-colors hover:border-primary/60 hover:bg-primary/10"
+                        >
+                          <span className="font-medium">{player.nombre}</span>
+                          <Badge className="bg-primary/10 text-primary">
+                            {entry.minutes}&apos;
+                          </Badge>
+                        </a>
+                      );
+                    })}
                   </div>
                 )}
               </CardContent>
             </Card>
-            <div className="flex flex-col gap-6">
-              <EventManager
-                initialEvents={match.events}
-                players={players}
-                teamId={match.teamId}
-                rivalId={match.rivalId}
-                addEvent={addEvent}
-                updateEvent={updateEvent}
-                deleteEvent={deleteEvent}
-              />
-              <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-                <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-                  <CardTitle>Convocatoria</CardTitle>
-                  <CardDescription className="text-slate-400">
-                    Distribución de la plantilla entre titulares, suplentes y desconvocados.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <div className="flex items-center justify-between text-sm font-semibold">
-                      <span>Titulares</span>
-                      <Badge variant="outline" className="border-slate-700/70 text-white">
-                        {starters.length}
-                      </Badge>
-                    </div>
-                    {renderPlayerList(starters, "Sin titulares asignados")}
-                  </div>
-                  <div>
-                    <div className="flex items-center justify-between text-sm font-semibold">
-                      <span>Suplentes</span>
-                      <Badge variant="outline" className="border-slate-700/70 text-white">
-                        {bench.length}
-                      </Badge>
-                    </div>
-                    {renderPlayerList(bench, "Sin suplentes seleccionados")}
-                  </div>
-                  <div>
-                    <div className="flex items-center justify-between text-sm font-semibold">
-                      <span>Desconvocados</span>
-                      <Badge variant="outline" className="border-slate-700/70 text-white">
-                        {unavailable.length}
-                      </Badge>
-                    </div>
-                    {renderPlayerList(
-                      unavailable,
-                      "Todos los jugadores fueron convocados"
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-              <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-                <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-                  <CardTitle>Minutos jugados</CardTitle>
-                  <CardDescription className="text-slate-400">
-                    Seguimiento del tiempo en cancha de los jugadores utilizados.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {minutesData.length === 0 ? (
-                    <p className="text-sm text-slate-400">
-                      Todavía no hay minutos registrados en este encuentro.
-                    </p>
-                  ) : (
-                    minutesSorted.map((entry) => {
-                      const player = playerMap.get(entry.id);
-                      if (!player) return null;
-                      const percentage = Math.min(
-                        100,
-                        Math.round((entry.minutes / maxMinutes) * 100)
-                      );
-                      return (
-                        <div key={entry.id} className="space-y-2">
-                          <div className="flex items-center justify-between text-sm font-medium">
-                            <span>{player.nombre}</span>
-                            <span>{entry.minutes}&apos;</span>
-                          </div>
-                          <div className="h-2 w-full rounded-full bg-slate-800">
-                            <div
-                              className="h-full rounded-full bg-primary"
-                              style={{ width: `${percentage}%` }}
-                            />
-                          </div>
-                        </div>
-                      );
-                    })
-                  )}
-                </CardContent>
-              </Card>
-            </div>
           </div>
-          <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-            <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-              <CardTitle>Valoraciones</CardTitle>
-              <CardDescription className="text-slate-400">
-                Accede rápidamente a la ficha de valoración de cada jugador con minutos.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {minutesData.length === 0 ? (
-                <p className="text-sm text-slate-400">
-                  Una vez que registres minutos podrás valorar el rendimiento individual.
-                </p>
-              ) : (
-                <div className="flex flex-wrap gap-2">
-                  {minutesSorted.map((entry) => {
-                    const player = playerMap.get(entry.id);
-                    if (!player) return null;
-                    return (
-                      <a
-                        key={entry.id}
-                        href={`/dashboard/valoraciones?jugador=${entry.id}`}
-                        className="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900 px-3 py-1 text-sm transition-colors hover:border-primary/60 hover:bg-primary/10"
-                      >
-                        <span className="font-medium">{player.nombre}</span>
-                        <Badge className="bg-primary/10 text-primary">
-                          {entry.minutes}&apos;
-                        </Badge>
-                      </a>
-                    );
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <div className="flex flex-col gap-6">
+            <EventManager
+              initialEvents={match.events}
+              players={players}
+              teamId={match.teamId}
+              rivalId={match.rivalId}
+              addEvent={addEvent}
+              updateEvent={updateEvent}
+              deleteEvent={deleteEvent}
+            />
+            <MatchAdminPanel
+              match={match}
+              teams={teams}
+              rivals={rivals}
+              onUpdate={updateMatch}
+              onDelete={deleteMatch}
+            />
+          </div>
         </div>
       </main>
     </div>

--- a/src/app/dashboard/partidos/[id]/match-summary.tsx
+++ b/src/app/dashboard/partidos/[id]/match-summary.tsx
@@ -1,15 +1,24 @@
 import { Badge } from "@/components/ui/badge";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { updateLineup } from "@/lib/api/matches";
 import { cn } from "@/lib/utils";
-import type { Match, MatchEvent } from "@/types/match";
+import type { Match, MatchEvent, PlayerSlot } from "@/types/match";
+import { revalidatePath } from "next/cache";
 import EventManager from "./event-manager";
 import MatchAdminPanel from "./match-admin-panel";
+import MinutesEditor from "./minutes-editor";
 import type { LucideIcon } from "lucide-react";
 import { Clock3, Goal, Octagon, Sparkles, Square } from "lucide-react";
 
@@ -139,6 +148,23 @@ export default function MatchSummary({
     ? Math.max(90, ...minutesData.map((item) => item.minutes))
     : 90;
 
+  const goalkeepers = match.lineup
+    .filter(
+      (slot) =>
+        slot.playerId &&
+        typeof slot.position === "string" &&
+        slot.position.toUpperCase() === "GK"
+    )
+    .map((slot) => ({
+      slot,
+      player: playerMap.get(slot.playerId as number),
+    }));
+  const totalCleanSheets = goalkeepers.filter((item) => item.slot.cleanSheet).length;
+  const totalGoalsConceded = goalkeepers.reduce(
+    (sum, item) => sum + (item.slot.goalsConceded ?? 0),
+    0
+  );
+
   const timelineEvents = [...match.events].sort((a, b) => a.minute - b.minute);
 
   const eventBreakdown = match.events.reduce(
@@ -163,14 +189,14 @@ export default function MatchSummary({
 
   function renderPlayerList(items: Player[], emptyMessage: string) {
     if (!items.length) {
-      return <p className="text-sm text-slate-400">{emptyMessage}</p>;
+      return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
     }
     const sorted = [...items].sort((a, b) => a.nombre.localeCompare(b.nombre));
     return (
-      <ul className="mt-2 grid gap-1 text-sm text-slate-200/90">
+      <ul className="mt-2 grid gap-1 text-sm text-slate-700">
         {sorted.map((player) => (
           <li key={player.id} className="flex items-center gap-2">
-            <span className="h-2 w-2 rounded-full bg-primary/70" aria-hidden />
+            <span className="h-2 w-2 rounded-full bg-primary/60" aria-hidden />
             <span>{player.nombre}</span>
           </li>
         ))}
@@ -208,106 +234,109 @@ export default function MatchSummary({
       : `Perdimos ${ourGoals}-${rivalGoals} ${locationSummary} ante ${opponentName}.`;
 
   let resultLabel = "Empate";
-  let resultClass = "border-slate-500/50 bg-slate-800/70 text-slate-200";
+  let resultClass = "border-slate-200 bg-slate-100 text-slate-600";
   if (ourGoals > rivalGoals) {
     resultLabel = "Victoria";
-    resultClass = "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+    resultClass = "border-emerald-200 bg-emerald-50 text-emerald-700";
   } else if (ourGoals < rivalGoals) {
     resultLabel = "Derrota";
-    resultClass = "border-rose-500/40 bg-rose-500/10 text-rose-300";
+    resultClass = "border-rose-200 bg-rose-50 text-rose-700";
+  }
+
+  const matchId = match.id;
+  const opponentNotes = match.opponentNotes ?? null;
+
+  async function handleSaveLineup(lineup: PlayerSlot[]) {
+    "use server";
+    await updateLineup(matchId, lineup, opponentNotes, true);
+    revalidatePath(`/dashboard/partidos/${matchId}`);
+    revalidatePath("/dashboard/partidos");
   }
 
   return (
-    <div className="min-h-screen w-full bg-slate-950 text-slate-100">
-      <section className="relative px-4 pb-6 pt-8 sm:px-6 lg:px-10">
-        <div
-          className="absolute inset-0 -z-10 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900"
-          aria-hidden
-        />
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl backdrop-blur">
-          <div className="flex flex-wrap items-center justify-between gap-6">
-            <div className="flex flex-1 flex-wrap items-center gap-6">
-              <div className="flex items-center gap-3">
-                <div
-                  className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
-                  style={{ backgroundColor: homeTeamColor, color: homeContrast }}
-                >
-                  {homeTeamName.slice(0, 2).toUpperCase()}
+    <div className="min-h-screen w-full bg-gradient-to-b from-slate-50 via-white to-slate-100 text-slate-900">
+      <section className="px-4 pb-6 pt-8 sm:px-6 lg:px-10">
+        <div className="mx-auto w-full max-w-5xl space-y-6">
+          <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-xl backdrop-blur-sm">
+            <div className="flex flex-wrap items-center justify-between gap-6">
+              <div className="flex flex-1 flex-wrap items-center gap-6">
+                <div className="flex items-center gap-3">
+                  <div
+                    className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
+                    style={{ backgroundColor: homeTeamColor, color: homeContrast }}
+                  >
+                    {homeTeamName.slice(0, 2).toUpperCase()}
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {homeLabel}
+                    </p>
+                    <p className="text-lg font-semibold text-slate-900">{homeTeamName}</p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-slate-300">
-                    {homeLabel}
-                  </p>
-                  <p className="text-lg font-semibold text-white">
-                    {homeTeamName}
-                  </p>
+                <div className="flex items-center gap-3 text-4xl font-bold tabular-nums text-slate-900 sm:text-5xl">
+                  <span>{homeGoals}</span>
+                  <span className="text-muted-foreground">-</span>
+                  <span>{awayGoals}</span>
                 </div>
-              </div>
-              <div className="flex items-center gap-3 text-4xl font-bold tabular-nums text-white sm:text-5xl">
-                <span>{homeGoals}</span>
-                <span className="text-slate-400">-</span>
-                <span>{awayGoals}</span>
-              </div>
-              <div className="flex items-center gap-3">
-                <div
-                  className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
-                  style={{ backgroundColor: awayTeamColor, color: awayContrast }}
-                >
-                  {awayTeamName.slice(0, 2).toUpperCase()}
-                </div>
-                <div>
-                  <p className="text-xs uppercase tracking-wide text-slate-300">
-                    {awayLabel}
-                  </p>
-                  <p className="text-lg font-semibold text-white">
-                    {awayTeamName}
-                  </p>
+                <div className="flex items-center gap-3">
+                  <div
+                    className="flex h-12 w-12 items-center justify-center rounded-full text-lg font-bold shadow-lg"
+                    style={{ backgroundColor: awayTeamColor, color: awayContrast }}
+                  >
+                    {awayTeamName.slice(0, 2).toUpperCase()}
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {awayLabel}
+                    </p>
+                    <p className="text-lg font-semibold text-slate-900">{awayTeamName}</p>
+                  </div>
                 </div>
               </div>
-            </div>
-            <Badge
-              variant="outline"
-              className={cn(
-                "border px-3 py-1 text-sm font-semibold uppercase tracking-wide",
-                resultClass
-              )}
-            >
-              {resultLabel}
-            </Badge>
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-slate-200/90">
-            <div className="flex items-center gap-3">
-              <Badge variant="outline" className="border-white/20 bg-white/10 text-white">
-                {competitionLabel}
+              <Badge
+                variant="outline"
+                className={cn(
+                  "border px-3 py-1 text-sm font-semibold uppercase tracking-wide",
+                  resultClass
+                )}
+              >
+                {resultLabel}
               </Badge>
-              {match.matchday ? <span>Jornada {match.matchday}</span> : null}
             </div>
-            <div className="flex flex-wrap items-center gap-3 text-xs sm:text-sm">
-              <Clock3 className="h-4 w-4" />
-              <span>{formattedKickoff}</span>
+            <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-3">
+                <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
+                  {competitionLabel}
+                </Badge>
+                {match.matchday ? (
+                  <span className="font-medium text-slate-900">Jornada {match.matchday}</span>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2 text-xs sm:text-sm">
+                <Clock3 className="h-4 w-4 text-muted-foreground" />
+                <span>{formattedKickoff}</span>
+              </div>
             </div>
           </div>
         </div>
       </section>
       <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 pb-10 sm:px-6 lg:px-10">
-        <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-          <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+        <Card>
+          <CardHeader className="space-y-2">
             <CardTitle>Timeline del partido</CardTitle>
-            <CardDescription className="text-slate-400">
+            <CardDescription>
               Repasa los momentos clave minuto a minuto justo debajo del marcador.
             </CardDescription>
           </CardHeader>
           <CardContent className="relative pr-4">
             {timelineEvents.length === 0 ? (
-              <p className="text-sm text-slate-400">
+              <p className="text-sm text-muted-foreground">
                 Aún no se registraron eventos para este partido.
               </p>
             ) : (
               <div className="relative space-y-6 pb-6 pl-5">
-                <div
-                  className="absolute left-2 top-0 h-full w-px bg-slate-700"
-                  aria-hidden
-                />
+                <div className="absolute left-2 top-0 h-full w-px bg-slate-200" aria-hidden />
                 <ul className="space-y-6">
                   {timelineEvents.map((event) => {
                     const descriptor = EVENT_CONFIG[event.type] ?? DEFAULT_EVENT;
@@ -330,16 +359,16 @@ export default function MatchSummary({
                             "absolute left-[-10px] top-2 h-3 w-3 rounded-full border",
                             descriptor.dotClass,
                             isOurEvent
-                              ? "ring-2 ring-emerald-400/70"
+                              ? "ring-2 ring-emerald-300/70"
                               : isRivalEvent
-                              ? "ring-2 ring-rose-400/70"
-                              : "ring-2 ring-slate-500/60"
+                              ? "ring-2 ring-rose-300/70"
+                              : "ring-2 ring-slate-300/70"
                           )}
                           aria-hidden
                         />
                         <div className="flex flex-wrap items-start justify-between gap-3">
                           <div className="space-y-1">
-                            <div className="flex items-center gap-2 text-sm font-semibold">
+                            <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
                               <span
                                 className={cn(
                                   "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
@@ -349,19 +378,15 @@ export default function MatchSummary({
                                 <Icon className="h-3.5 w-3.5" />
                                 {descriptor.label}
                               </span>
-                              {playerName ? (
-                                <span className="text-sm font-medium text-white">
-                                  {playerName}
-                                </span>
-                              ) : null}
+                              {playerName ? <span>{playerName}</span> : null}
                             </div>
-                            <div className="flex items-center gap-2 text-xs text-slate-400">
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
                               {isOurEvent ? (
-                                <Badge className="bg-emerald-500/10 text-emerald-300">
+                                <Badge className="border border-emerald-200 bg-emerald-50 text-emerald-700">
                                   Nuestro equipo
                                 </Badge>
                               ) : isRivalEvent ? (
-                                <Badge className="bg-rose-500/10 text-rose-300">
+                                <Badge className="border border-rose-200 bg-rose-50 text-rose-700">
                                   Rival
                                 </Badge>
                               ) : null}
@@ -370,7 +395,7 @@ export default function MatchSummary({
                               ) : null}
                             </div>
                           </div>
-                          <Badge variant="outline" className="border-slate-700/70 text-xs font-semibold text-white">
+                          <Badge className="border border-slate-200 bg-slate-50 text-xs font-semibold text-slate-700">
                             {event.minute}&apos;
                           </Badge>
                         </div>
@@ -384,120 +409,104 @@ export default function MatchSummary({
         </Card>
         <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
           <div className="flex flex-col gap-6">
-            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+            <Card>
+              <CardHeader className="space-y-2">
                 <CardTitle>Resumen del partido</CardTitle>
-                <CardDescription className="text-slate-300">
-                  {summaryText}
-                </CardDescription>
+                <CardDescription>{summaryText}</CardDescription>
               </CardHeader>
               <CardContent className="grid gap-6 md:grid-cols-2">
-                <div className="space-y-3 text-sm text-slate-200/90">
-                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                    <span className="text-slate-400">Competición</span>
-                    <span className="font-semibold text-white">{competitionLabel}</span>
+                <div className="space-y-3 text-sm text-slate-700">
+                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                    <span className="text-muted-foreground">Competición</span>
+                    <span className="font-semibold text-slate-900">{competitionLabel}</span>
                   </div>
                   {match.matchday ? (
-                    <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                      <span className="text-slate-400">Jornada</span>
-                      <span className="font-semibold text-white">{match.matchday}</span>
+                    <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                      <span className="text-muted-foreground">Jornada</span>
+                      <span className="font-semibold text-slate-900">{match.matchday}</span>
                     </div>
                   ) : null}
-                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                    <span className="text-slate-400">Condición</span>
-                    <span className="font-semibold text-white">
+                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                    <span className="text-muted-foreground">Condición</span>
+                    <span className="font-semibold text-slate-900">
                       {match.isHome ? "Local" : "Visitante"}
                     </span>
                   </div>
-                  <div className="flex items-center justify-between rounded-lg border border-slate-800/60 bg-slate-900/80 px-4 py-3">
-                    <span className="text-slate-400">Fecha</span>
-                    <span className="font-semibold text-white">{formattedKickoff}</span>
+                  <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                    <span className="text-muted-foreground">Fecha</span>
+                    <span className="font-semibold text-slate-900">{formattedKickoff}</span>
                   </div>
                 </div>
-                <div className="grid gap-3 text-sm text-slate-200/90">
-                  <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
-                    <h4 className="text-xs uppercase tracking-wide text-slate-400">
+                <div className="grid gap-3 text-sm text-slate-700">
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <h4 className="text-xs uppercase tracking-wide text-muted-foreground">
                       Nuestro equipo
                     </h4>
                     <dl className="mt-2 space-y-2">
                       <div className="flex items-center justify-between">
                         <dt>Goles</dt>
-                        <dd className="font-semibold text-white">
-                          {eventBreakdown.ours.goals}
-                        </dd>
+                        <dd className="font-semibold text-slate-900">{eventBreakdown.ours.goals}</dd>
                       </div>
                       <div className="flex items-center justify-between">
                         <dt>Tarjetas amarillas</dt>
-                        <dd className="font-semibold text-amber-300">
-                          {eventBreakdown.ours.yellow}
-                        </dd>
+                        <dd className="font-semibold text-amber-600">{eventBreakdown.ours.yellow}</dd>
                       </div>
                       <div className="flex items-center justify-between">
                         <dt>Tarjetas rojas</dt>
-                        <dd className="font-semibold text-rose-300">
-                          {eventBreakdown.ours.red}
-                        </dd>
+                        <dd className="font-semibold text-rose-600">{eventBreakdown.ours.red}</dd>
                       </div>
                     </dl>
                   </div>
-                  <div className="rounded-lg border border-slate-800/60 bg-slate-900/80 p-4">
-                    <h4 className="text-xs uppercase tracking-wide text-slate-400">
-                      Rival
-                    </h4>
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <h4 className="text-xs uppercase tracking-wide text-muted-foreground">Rival</h4>
                     <dl className="mt-2 space-y-2">
                       <div className="flex items-center justify-between">
                         <dt>Goles</dt>
-                        <dd className="font-semibold text-white">
-                          {eventBreakdown.rival.goals}
-                        </dd>
+                        <dd className="font-semibold text-slate-900">{eventBreakdown.rival.goals}</dd>
                       </div>
                       <div className="flex items-center justify-between">
                         <dt>Tarjetas amarillas</dt>
-                        <dd className="font-semibold text-amber-300">
-                          {eventBreakdown.rival.yellow}
-                        </dd>
+                        <dd className="font-semibold text-amber-600">{eventBreakdown.rival.yellow}</dd>
                       </div>
                       <div className="flex items-center justify-between">
                         <dt>Tarjetas rojas</dt>
-                        <dd className="font-semibold text-rose-300">
-                          {eventBreakdown.rival.red}
-                        </dd>
+                        <dd className="font-semibold text-rose-600">{eventBreakdown.rival.red}</dd>
                       </div>
                     </dl>
                   </div>
                 </div>
               </CardContent>
             </Card>
-            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
+            <Card>
+              <CardHeader className="space-y-2">
                 <CardTitle>Convocatoria</CardTitle>
-                <CardDescription className="text-slate-400">
+                <CardDescription>
                   Distribución de la plantilla entre titulares, suplentes y desconvocados.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div>
-                  <div className="flex items-center justify-between text-sm font-semibold">
+                  <div className="flex items-center justify-between text-sm font-semibold text-slate-900">
                     <span>Titulares</span>
-                    <Badge variant="outline" className="border-slate-700/70 text-white">
+                    <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
                       {starters.length}
                     </Badge>
                   </div>
                   {renderPlayerList(starters, "Sin titulares asignados")}
                 </div>
                 <div>
-                  <div className="flex items-center justify-between text-sm font-semibold">
+                  <div className="flex items-center justify-between text-sm font-semibold text-slate-900">
                     <span>Suplentes</span>
-                    <Badge variant="outline" className="border-slate-700/70 text-white">
+                    <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
                       {bench.length}
                     </Badge>
                   </div>
                   {renderPlayerList(bench, "Sin suplentes seleccionados")}
                 </div>
                 <div>
-                  <div className="flex items-center justify-between text-sm font-semibold">
+                  <div className="flex items-center justify-between text-sm font-semibold text-slate-900">
                     <span>Desconvocados</span>
-                    <Badge variant="outline" className="border-slate-700/70 text-white">
+                    <Badge className="border border-slate-200 bg-slate-100 text-slate-700">
                       {unavailable.length}
                     </Badge>
                   </div>
@@ -508,96 +517,143 @@ export default function MatchSummary({
                 </div>
               </CardContent>
             </Card>
-            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-                <CardTitle>Minutos jugados</CardTitle>
-                <CardDescription className="text-slate-400">
-                  Seguimiento del tiempo en cancha de los jugadores utilizados.
-                </CardDescription>
+            <Card>
+              <CardHeader className="space-y-4 sm:flex sm:items-center sm:justify-between sm:space-y-0">
+                <div className="space-y-2">
+                  <CardTitle>Minutos jugados</CardTitle>
+                  <CardDescription>
+                    Seguimiento del tiempo en cancha de los jugadores utilizados.
+                  </CardDescription>
+                </div>
+                <MinutesEditor
+                  lineup={match.lineup}
+                  players={players}
+                  onSave={handleSaveLineup}
+                />
               </CardHeader>
-              <CardContent className="space-y-4">
-                {minutesData.length === 0 ? (
-                  <p className="text-sm text-slate-400">
-                    Todavía no hay minutos registrados en este encuentro.
+              <CardContent className="space-y-6">
+                {minutesSorted.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    Aún no se han registrado minutos para este partido.
                   </p>
                 ) : (
-                  minutesSorted.map((entry) => {
-                    const player = playerMap.get(entry.id);
-                    if (!player) return null;
-                    const percentage = Math.min(
-                      100,
-                      Math.round((entry.minutes / maxMinutes) * 100)
-                    );
-                    return (
-                      <div key={entry.id} className="space-y-2">
-                        <div className="flex items-center justify-between text-sm font-medium">
-                          <span>{player.nombre}</span>
-                          <span>{entry.minutes}&apos;</span>
-                        </div>
-                        <div className="h-2 w-full rounded-full bg-slate-800">
-                          <div
-                            className="h-full rounded-full bg-primary"
-                            style={{ width: `${percentage}%` }}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })
-                )}
-              </CardContent>
-            </Card>
-            <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
-              <CardHeader className="space-y-2 border-b border-slate-800/60 pb-4">
-                <CardTitle>Valoraciones</CardTitle>
-                <CardDescription className="text-slate-400">
-                  Accede rápidamente a la ficha de valoración de cada jugador con minutos.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {minutesData.length === 0 ? (
-                  <p className="text-sm text-slate-400">
-                    Una vez que registres minutos podrás valorar el rendimiento individual.
-                  </p>
-                ) : (
-                  <div className="flex flex-wrap gap-2">
+                  <div className="space-y-4">
                     {minutesSorted.map((entry) => {
                       const player = playerMap.get(entry.id);
                       if (!player) return null;
+                      const percentage = Math.min(
+                        100,
+                        Math.round((entry.minutes / maxMinutes) * 100)
+                      );
                       return (
-                        <a
-                          key={entry.id}
-                          href={`/dashboard/valoraciones?jugador=${entry.id}`}
-                          className="inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900 px-3 py-1 text-sm transition-colors hover:border-primary/60 hover:bg-primary/10"
-                        >
-                          <span className="font-medium">{player.nombre}</span>
-                          <Badge className="bg-primary/10 text-primary">
-                            {entry.minutes}&apos;
-                          </Badge>
-                        </a>
+                        <div key={entry.id} className="space-y-2">
+                          <div className="flex items-center justify-between text-sm font-medium text-slate-900">
+                            <span>{player.nombre}</span>
+                            <span>{entry.minutes}&apos;</span>
+                          </div>
+                          <div className="h-2 w-full rounded-full bg-slate-200">
+                            <div
+                              className="h-full rounded-full bg-primary"
+                              style={{ width: `${percentage}%` }}
+                            />
+                          </div>
+                        </div>
                       );
                     })}
                   </div>
                 )}
+                {goalkeepers.length ? (
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                      <p className="text-sm font-medium text-emerald-700">Porterías a cero</p>
+                      <p className="text-2xl font-semibold text-emerald-700">{totalCleanSheets}</p>
+                      <p className="text-xs text-emerald-700/80">
+                        Marca el interruptor correspondiente al editar minutos.
+                      </p>
+                    </div>
+                    <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+                      <p className="text-sm font-medium text-slate-900">Goles encajados</p>
+                      <p className="text-2xl font-semibold text-rose-600">{totalGoalsConceded}</p>
+                      <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                        {goalkeepers.map((item) => (
+                          <li key={item.slot.playerId}>
+                            {item.player?.nombre ?? `Jugador ${item.slot.playerId}`} · {item.slot.goalsConceded ?? 0} goles
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-muted-foreground">
+                    Registra al menos un guardameta en la alineación para controlar las porterías a cero y goles encajados.
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="space-y-2">
+                <CardTitle>Valoraciones</CardTitle>
+                <CardDescription>
+                  Accede rápidamente a la ficha de valoración de cada jugador con minutos.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {match.lineup
+                    .filter((slot) => slot.playerId && slot.role !== "unavailable")
+                    .map((slot) => {
+                      const player = playerMap.get(slot.playerId as number);
+                      if (!player) return null;
+                      return (
+                        <a
+                          key={slot.playerId}
+                          href={`/dashboard/valoraciones?jugador=${slot.playerId}`}
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-sm transition-colors hover:border-primary/60 hover:bg-primary/10"
+                        >
+                          <span className="font-medium text-slate-900">{player.nombre}</span>
+                          <Badge className="border border-primary/40 bg-primary/10 text-xs font-semibold text-primary">
+                            {slot.minutes ?? 0}&apos;
+                          </Badge>
+                        </a>
+                      );
+                    })}
+                </div>
               </CardContent>
             </Card>
           </div>
-          <div className="flex flex-col gap-6">
-            <EventManager
-              initialEvents={match.events}
-              players={players}
-              teamId={match.teamId}
-              rivalId={match.rivalId}
-              addEvent={addEvent}
-              updateEvent={updateEvent}
-              deleteEvent={deleteEvent}
-            />
-            <MatchAdminPanel
-              match={match}
-              teams={teams}
-              rivals={rivals}
-              onUpdate={updateMatch}
-              onDelete={deleteMatch}
-            />
+          <div className="flex flex-col gap-4">
+            <Accordion type="multiple" className="space-y-4">
+              <AccordionItem value="events">
+                <AccordionTrigger className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-left text-base font-semibold shadow-sm hover:bg-slate-50">
+                  Gestionar eventos
+                </AccordionTrigger>
+                <AccordionContent className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                  <EventManager
+                    initialEvents={match.events}
+                    players={players}
+                    teamId={match.teamId}
+                    rivalId={match.rivalId}
+                    addEvent={addEvent}
+                    updateEvent={updateEvent}
+                    deleteEvent={deleteEvent}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="admin">
+                <AccordionTrigger className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-left text-base font-semibold shadow-sm hover:bg-slate-50">
+                  Administrar partido
+                </AccordionTrigger>
+                <AccordionContent className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+                  <MatchAdminPanel
+                    match={match}
+                    teams={teams}
+                    rivals={rivals}
+                    onUpdate={updateMatch}
+                    onDelete={deleteMatch}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           </div>
         </div>
       </main>

--- a/src/app/dashboard/partidos/[id]/minutes-editor.tsx
+++ b/src/app/dashboard/partidos/[id]/minutes-editor.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Switch } from "@/components/ui/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { PlayerSlot } from "@/types/match";
+
+interface PlayerOption {
+  id: number;
+  nombre: string;
+}
+
+interface MinutesEditorProps {
+  lineup: PlayerSlot[];
+  players: PlayerOption[];
+  onSave: (lineup: PlayerSlot[]) => Promise<void>;
+}
+
+interface EditableRow {
+  playerId: number;
+  name: string;
+  role: PlayerSlot["role"];
+  position?: string;
+  minutes: string;
+  cleanSheet: boolean;
+  goalsConceded: string;
+  isGoalkeeper: boolean;
+}
+
+const ROLE_LABELS: Record<PlayerSlot["role"], string> = {
+  field: "Titular",
+  bench: "Suplente",
+  unavailable: "Desconvocado",
+};
+
+function buildRows(
+  lineup: PlayerSlot[],
+  players: PlayerOption[]
+): EditableRow[] {
+  const order: Record<PlayerSlot["role"], number> = {
+    field: 0,
+    bench: 1,
+    unavailable: 2,
+  };
+  const playerMap = new Map(players.map((player) => [player.id, player]));
+  return lineup
+    .slice()
+    .sort((a, b) => {
+      const roleDiff = order[a.role] - order[b.role];
+      if (roleDiff !== 0) return roleDiff;
+      const nameA = playerMap.get(a.playerId)?.nombre ?? "";
+      const nameB = playerMap.get(b.playerId)?.nombre ?? "";
+      return nameA.localeCompare(nameB);
+    })
+    .map((slot) => {
+      const player = playerMap.get(slot.playerId);
+      const position = slot.position;
+      const isGoalkeeper = (position ?? "").toUpperCase() === "GK";
+      return {
+        playerId: slot.playerId,
+        name: player?.nombre ?? `Jugador ${slot.playerId}`,
+        role: slot.role,
+        position,
+        minutes: String(slot.minutes ?? 0),
+        cleanSheet: Boolean(slot.cleanSheet),
+        goalsConceded: String(slot.goalsConceded ?? 0),
+        isGoalkeeper,
+      };
+    });
+}
+
+export default function MinutesEditor({
+  lineup,
+  players,
+  onSave,
+}: MinutesEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [rows, setRows] = useState<EditableRow[]>(() =>
+    buildRows(lineup, players)
+  );
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (open) {
+      setRows(buildRows(lineup, players));
+    }
+  }, [open, lineup, players]);
+
+  function updateRow(playerId: number, patch: Partial<EditableRow>) {
+    setRows((current) =>
+      current.map((row) =>
+        row.playerId === playerId ? { ...row, ...patch } : row
+      )
+    );
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    startTransition(async () => {
+      try {
+        const updates = lineup.map((slot) => {
+          const row = rows.find((item) => item.playerId === slot.playerId);
+          if (!row) {
+            return slot;
+          }
+          const minutesValue = Number(row.minutes);
+          const goalsConcededValue = Number(row.goalsConceded);
+          return {
+            ...slot,
+            minutes: Number.isFinite(minutesValue)
+              ? Math.max(0, Math.round(minutesValue))
+              : slot.minutes,
+            cleanSheet: row.cleanSheet,
+            goalsConceded: Number.isFinite(goalsConcededValue)
+              ? Math.max(0, Math.round(goalsConcededValue))
+              : slot.goalsConceded ?? 0,
+          } satisfies PlayerSlot;
+        });
+        await onSave(updates);
+        toast.success("Minutos actualizados correctamente");
+        setOpen(false);
+      } catch (error) {
+        console.error("No se pudieron guardar los minutos", error);
+        toast.error("No se pudieron guardar los cambios");
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          Editar minutos
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Actualizar minutos y porterías a cero</DialogTitle>
+          <DialogDescription>
+            Ajusta los minutos jugados, marca porterías a cero y registra los
+            goles encajados para tus guardametas.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <ScrollArea className="max-h-[60vh] pr-2">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Jugador</TableHead>
+                  <TableHead className="w-32 text-center">Minutos</TableHead>
+                  <TableHead className="w-40 text-center">
+                    Portería a 0
+                  </TableHead>
+                  <TableHead className="w-36 text-center">
+                    Goles encajados
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.playerId}>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium text-foreground">
+                          {row.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {ROLE_LABELS[row.role]}
+                          {row.position ? ` • ${row.position}` : ""}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <div className="flex flex-col items-center gap-1">
+                        <Label htmlFor={`minutes-${row.playerId}`} className="sr-only">
+                          Minutos jugados
+                        </Label>
+                        <Input
+                          id={`minutes-${row.playerId}`}
+                          inputMode="numeric"
+                          pattern="[0-9]*"
+                          value={row.minutes}
+                          onChange={(event) =>
+                            updateRow(row.playerId, {
+                              minutes: event.target.value.replace(/[^0-9]/g, ""),
+                            })
+                          }
+                          className="h-9 w-24 text-center"
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      {row.isGoalkeeper ? (
+                        <div className="flex items-center justify-center gap-2">
+                          <Switch
+                            checked={row.cleanSheet}
+                            onCheckedChange={(value) =>
+                              updateRow(row.playerId, { cleanSheet: value })
+                            }
+                            aria-label="Marcar portería a cero"
+                          />
+                        </div>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      {row.isGoalkeeper ? (
+                        <div className="flex flex-col items-center gap-1">
+                          <Label
+                            htmlFor={`goals-${row.playerId}`}
+                            className="sr-only"
+                          >
+                            Goles encajados
+                          </Label>
+                          <Input
+                            id={`goals-${row.playerId}`}
+                            inputMode="numeric"
+                            pattern="[0-9]*"
+                            value={row.goalsConceded}
+                            onChange={(event) =>
+                              updateRow(row.playerId, {
+                                goalsConceded: event.target.value.replace(
+                                  /[^0-9]/g,
+                                  ""
+                                ),
+                              })
+                            }
+                            className="h-9 w-24 text-center"
+                          />
+                        </div>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </ScrollArea>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isPending}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Guardando..." : "Guardar cambios"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api/matches.ts
+++ b/src/lib/api/matches.ts
@@ -30,6 +30,21 @@ function toNullableNumber(value: any): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function toBoolean(value: any): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return false;
+    return ['true', '1', 'si', 'sí', 'yes', 'y', 'on'].includes(normalized);
+  }
+  return false;
+}
+
 function getSql(): SqlClient | null {
   const connectionString =
     process.env['DATABASE_URL'] ||
@@ -52,7 +67,12 @@ function sanitizeLineup(input: any): PlayerSlot[] {
     const role =
       raw?.role === 'bench' || raw?.role === 'unavailable' ? raw.role : 'field';
     const number = toNullableNumber(raw?.number ?? raw?.dorsal) ?? undefined;
-    const minutes = Math.max(0, toNumber(raw?.minutes, 0));
+    const minutes = Math.max(0, toNumber(raw?.minutes ?? raw?.minutos, 0));
+    const cleanSheet = toBoolean(raw?.cleanSheet ?? raw?.clean_sheet);
+    const goalsConceded = Math.max(
+      0,
+      toNumber(raw?.goalsConceded ?? raw?.goals_conceded, 0)
+    );
     const position =
       typeof raw?.position === 'string' && raw.position.length
         ? raw.position
@@ -63,6 +83,8 @@ function sanitizeLineup(input: any): PlayerSlot[] {
       role,
       position,
       minutes,
+      cleanSheet,
+      goalsConceded,
     });
   });
   return lineup;

--- a/src/lib/match-events.ts
+++ b/src/lib/match-events.ts
@@ -1,0 +1,124 @@
+import type { MatchEvent } from "@/types/match";
+
+export type EventPeriod = "first" | "second" | "extra";
+
+export const HALF_DURATION_MINUTES = 40;
+export const DEFAULT_EVENT_PERIOD: EventPeriod = "first";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function coerceEventPeriod(value: unknown): EventPeriod {
+  if (value === "second" || value === "extra") {
+    return value;
+  }
+  return "first";
+}
+
+export function clampRelativeMinute(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(130, Math.round(value)));
+}
+
+export function toAbsoluteMinute(period: EventPeriod, relativeMinute: number): number {
+  const minute = clampRelativeMinute(relativeMinute);
+  switch (period) {
+    case "second":
+      return HALF_DURATION_MINUTES + minute;
+    case "extra":
+      return HALF_DURATION_MINUTES * 2 + minute;
+    default:
+      return minute;
+  }
+}
+
+export function toRelativeMinute(period: EventPeriod, absoluteMinute: number): number {
+  const minute = clampRelativeMinute(absoluteMinute);
+  switch (period) {
+    case "second":
+      return Math.max(0, minute - HALF_DURATION_MINUTES);
+    case "extra":
+      return Math.max(0, minute - HALF_DURATION_MINUTES * 2);
+    default:
+      return minute;
+  }
+}
+
+function getEventData(event: MatchEvent): Record<string, unknown> {
+  if (!isRecord(event.data)) {
+    return {};
+  }
+  return event.data as Record<string, unknown>;
+}
+
+export function getStoredRelativeMinute(event: MatchEvent): number | null {
+  const data = getEventData(event);
+  const value = data.relativeMinute;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return clampRelativeMinute(value);
+  }
+  return null;
+}
+
+export function getEventPeriod(event: MatchEvent): EventPeriod {
+  const data = getEventData(event);
+  const raw = data.period;
+  if (raw === "second" || raw === "extra") {
+    return raw;
+  }
+  if (event.minute > HALF_DURATION_MINUTES * 2) {
+    return "extra";
+  }
+  if (event.minute > HALF_DURATION_MINUTES) {
+    return "second";
+  }
+  return "first";
+}
+
+export function getEventRelativeMinute(event: MatchEvent): number {
+  const stored = getStoredRelativeMinute(event);
+  if (stored != null) {
+    return stored;
+  }
+  const period = getEventPeriod(event);
+  return toRelativeMinute(period, event.minute);
+}
+
+export function getEventAbsoluteMinute(event: MatchEvent): number {
+  const period = getEventPeriod(event);
+  const relative = getEventRelativeMinute(event);
+  return toAbsoluteMinute(period, relative);
+}
+
+export function buildEventMetadata(
+  period: EventPeriod,
+  relativeMinute: number,
+  base: Record<string, unknown> | null = null
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = base ? { ...base } : {};
+  metadata.period = period;
+  metadata.relativeMinute = clampRelativeMinute(relativeMinute);
+  return metadata;
+}
+
+export function formatPeriodLabel(period: EventPeriod): string {
+  switch (period) {
+    case "second":
+      return "2ª parte";
+    case "extra":
+      return "Prórroga";
+    default:
+      return "1ª parte";
+  }
+}
+
+export function formatEventMinute(period: EventPeriod, relativeMinute: number): string {
+  const absolute = toAbsoluteMinute(period, relativeMinute);
+  const suffix = formatPeriodLabel(period);
+  return period === "first"
+    ? `${absolute}'`
+    : `${absolute}' · ${suffix}`;
+}

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -12,6 +12,10 @@ export interface PlayerSlot {
   position?: string;
   /** Minutes played by the player in this match. */
   minutes: number;
+  /** Indicates whether the player mantained a clean sheet. */
+  cleanSheet?: boolean;
+  /** Number of goals conceded while this player was on the pitch (goalkeepers). */
+  goalsConceded?: number;
   /**
    * Second of match when the player entered the field. Used only on the
    * client to compute minutes played automatically and omitted when

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -58,3 +58,10 @@ export type NewMatchEvent = Omit<MatchEvent, 'id'>;
 export type UpdateMatchEvent = Partial<
   Pick<MatchEvent, 'minute' | 'type' | 'playerId' | 'teamId' | 'rivalId' | 'data'>
 >;
+
+export type UpdateMatchInput = Partial<
+  Pick<
+    Match,
+    'teamId' | 'rivalId' | 'isHome' | 'kickoff' | 'competition' | 'matchday' | 'opponentNotes' | 'finished'
+  >
+>;


### PR DESCRIPTION
## Summary
- add a dedicated match overview card with competition, date and cards statistics so the finished summary is accurate at a glance
- relax layout constraints in the finished match view to prevent content from being clipped and make screenshots easier

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db8100ec8883209a929fb5ce274501