### PR TITLE
Fix stats filtering and match clock half duration usage

### DIFF
--- a/src/app/dashboard/estadisticas/page.tsx
+++ b/src/app/dashboard/estadisticas/page.tsx
@@ -30,7 +30,14 @@ export default async function EstadisticasPage() {
 
   const teamMatches = matches
     .filter((match) => match.teamId === equipoId)
-    .filter((match) => match.finished)
+    .filter((match) => {
+      if (match.finished) {
+        return true
+      }
+      const hasMinutes = match.lineup.some((slot) => (slot.minutes ?? 0) > 0)
+      const hasEvents = match.events.length > 0
+      return hasMinutes || hasEvents
+    })
 
   const opponents: Record<number, string> = {}
   for (const rival of rivales as { id: number; nombre: string }[]) {

--- a/src/app/dashboard/partidos/[id]/match-detail.tsx
+++ b/src/app/dashboard/partidos/[id]/match-detail.tsx
@@ -55,6 +55,7 @@ import {
   List,
   LayoutGrid,
 } from "lucide-react";
+import { HALF_DURATION_MINUTES } from "@/lib/match-events";
 
 const POSITION_COORDS: Record<string, { x: number; y: number }> = {
   GK: { x: 10, y: 50 },
@@ -359,7 +360,8 @@ export default function MatchDetail({
   }, [running]);
 
   const currentMinute = useMemo(
-    () => Math.floor(seconds / 60) + (half - 1) * 40,
+    () =>
+      Math.floor(seconds / 60) + (half - 1) * HALF_DURATION_MINUTES,
     [seconds, half]
   );
 
@@ -512,7 +514,12 @@ export default function MatchDetail({
       fd.append("type", type);
       if (teamId) fd.append("teamId", String(teamId));
       if (rivalId) fd.append("rivalId", String(rivalId));
-      fd.append("minute", String(Math.floor(seconds / 60) + (half - 1) * 40));
+      fd.append(
+        "minute",
+        String(
+          Math.floor(seconds / 60) + (half - 1) * HALF_DURATION_MINUTES
+        )
+      );
       const created = await addEvent(fd);
       setEvents((prev) => [...prev, created]);
       toast(`Evento ${type} añadido`);
@@ -791,7 +798,8 @@ export default function MatchDetail({
     }
     setSubsMade((c) => c + 1);
     setSelectedBenchId(null);
-    const minute = Math.floor(liveSeconds / 60) + (half - 1) * 40;
+    const minute =
+      Math.floor(liveSeconds / 60) + (half - 1) * HALF_DURATION_MINUTES;
     if (minute >= 70 && !lateWindowUsed) {
       setLateWindowUsed(true);
       toast("Has consumido la ventana de cambios permitida tras el 70'.");
@@ -860,7 +868,10 @@ export default function MatchDetail({
               {running ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
             </Button>
             <span className="tabular-nums text-sm sm:text-xl">
-              {String(Math.floor(seconds / 60) + (half - 1) * 40).padStart(2, "0")}:
+              {String(
+                Math.floor(seconds / 60) +
+                  (half - 1) * HALF_DURATION_MINUTES
+              ).padStart(2, "0")}:
               {String(seconds % 60).padStart(2, "0")}
             </span>
             {half === 1 && !running && (


### PR DESCRIPTION
## Summary
- include matches with recorded data in the statistics dashboard even if they are not flagged as finished yet
- drive the interactive match clock and quick event minute calculations from the shared half-duration constant to keep periods aligned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff51327b1883209369eb28efbed625