### PR TITLE
Update dashboard summary cards with dynamic stats

### DIFF
--- a/src/app/dashboard/equipos/page.tsx
+++ b/src/app/dashboard/equipos/page.tsx
@@ -7,7 +7,6 @@ import { PlusCircle, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { SectionCards } from "@/components/section-cards"
 
 // Datos de ejemplo - en producción vendrían de la API
 const teams = [

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link"
-import { SectionCards } from "@/components/section-cards"
+import { SectionCards, type SectionCardsStats } from "@/components/section-cards"
 import JugadoresTable from "@/app/dashboard/jugadores/jugadores-table"
 import {
   equiposService,
@@ -8,6 +8,10 @@ import {
   entrenamientosService,
   rivalesService,
   sancionesService,
+  asistenciasService,
+  valoracionesService,
+  objetivosService,
+  temporadasService,
 } from "@/lib/api/services"
 import { listMatches } from "@/lib/api/matches"
 import type { Match, MatchEvent } from "@/types/match"
@@ -16,6 +20,8 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { AlertCircle, CalendarClock, Clock, Flag, ShieldAlert } from "lucide-react"
 import { setSanctionStatus } from "./sanctions-actions"
+
+export const dynamic = "force-dynamic"
 
 type JugadorConStats = Awaited<ReturnType<typeof jugadoresService.getByEquipo>> extends (infer T)[]
   ? T
@@ -170,8 +176,12 @@ async function safeListMatches(): Promise<Match[]> {
 }
 
 export default async function DashboardPage() {
-  const equipos = await equiposService.getAll()
-  const equipo = equipos[0]
+  const [equipos, temporada] = await Promise.all([
+    equiposService.getAll(),
+    temporadasService.getActual(),
+  ])
+
+  const equipo = equipos[0] ?? null
 
   const [jugadores, horarios, entrenamientos, rivales, storedSanctions, matches] = await Promise.all([
     equipo ? jugadoresService.getByEquipo(equipo.id) : Promise.resolve([]),
@@ -183,6 +193,94 @@ export default async function DashboardPage() {
   ])
 
   const storedSanctionsTyped = (storedSanctions ?? []) as StoredSanction[]
+
+  let temporadaEquipos = temporada
+    ? await equiposService.getByTemporada(temporada.id)
+    : equipos
+
+  if (temporadaEquipos.length === 0) {
+    temporadaEquipos = equipos
+  }
+
+  const seasonTeams = temporadaEquipos
+
+  const seasonPlayersByTeam = await Promise.all(
+    seasonTeams.map((team) => {
+      if (equipo && Number(team.id) === Number(equipo.id)) {
+        return Promise.resolve(jugadores as JugadorConStats[])
+      }
+      return jugadoresService.getByEquipo(team.id)
+    })
+  )
+
+  const seasonPlayers = seasonPlayersByTeam.flat() as JugadorConStats[]
+
+  const asistencias = (
+    await Promise.all(seasonTeams.map((team) => asistenciasService.getByEquipo(team.id)))
+  ).flat()
+
+  const objetivos = (
+    await Promise.all(seasonTeams.map((team) => objetivosService.getByEquipo(team.id)))
+  ).flat()
+
+  const valoraciones = (
+    await Promise.all(seasonPlayers.map((player) => valoracionesService.getByJugador(player.id)))
+  ).flat()
+
+  const attendanceAverage =
+    asistencias.length > 0
+      ? `${(
+          (asistencias.filter((registro) => {
+            if (typeof registro.asistio === "number") {
+              return registro.asistio > 0
+            }
+            return Boolean(registro.asistio)
+          }).length /
+            asistencias.length) *
+          100
+        ).toFixed(0)}%`
+      : "0%"
+
+  const ratingValues = valoraciones
+    .map((valoracion) => {
+      const entries = Object.values(valoracion.aptitudes ?? {})
+        .map((value) => Number(value))
+        .filter((value) => Number.isFinite(value))
+      if (entries.length === 0 || entries.every((value) => value === 0)) {
+        return null
+      }
+      return entries.reduce((sum, value) => sum + value, 0) / entries.length
+    })
+    .filter((value): value is number => value !== null)
+
+  const ratingAverage =
+    ratingValues.length > 0
+      ? (
+          ratingValues.reduce((sum, value) => sum + value, 0) /
+          ratingValues.length
+        ).toFixed(1)
+      : "0"
+
+  const objectivesCompletion =
+    objetivos.length > 0
+      ? `${(
+          (objetivos.filter((objetivo) => Number(objetivo.progreso ?? 0) >= 100).length /
+            objetivos.length) *
+          100
+        ).toFixed(0)}%`
+      : "0%"
+
+  const sectionCardsStats: SectionCardsStats = {
+    temporadaLabel: temporada?.nombre ?? temporada?.id ?? "N/A",
+    totalTeams: seasonTeams.length,
+    totalPlayers: seasonPlayers.length,
+    attendanceAverage,
+    attendanceRecords: asistencias.length,
+    ratingAverage,
+    ratingRecords: valoraciones.length,
+    objectivesCompletion,
+    objectivesCount: objetivos.length,
+  }
 
   const teamMap = new Map<number, string>()
   if (equipo) {
@@ -514,7 +612,7 @@ export default async function DashboardPage() {
         <p className="text-muted-foreground">Resumen global del rendimiento colectivo.</p>
       </div>
 
-      <SectionCards />
+      <SectionCards stats={sectionCardsStats} />
 
       <div className="mt-8 grid gap-4 px-4 lg:px-6 lg:grid-cols-2">
         <Card>

--- a/src/components/section-cards.tsx
+++ b/src/components/section-cards.tsx
@@ -7,79 +7,35 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  equiposService,
-  jugadoresService,
-  asistenciasService,
-  valoracionesService,
-  objetivosService,
-  temporadasService,
-} from "@/lib/api/services"
 
-interface Asistencia {
-  asistio: boolean | number
+export type SectionCardsStats = {
+  temporadaLabel: string
+  totalTeams: number
+  totalPlayers: number
+  attendanceAverage: string
+  attendanceRecords: number
+  ratingAverage: string
+  ratingRecords: number
+  objectivesCompletion: string
+  objectivesCount: number
 }
 
-export async function SectionCards() {
-  const temporada = await temporadasService.getActual()
-  let equipos = temporada
-    ? await equiposService.getByTemporada(temporada.id)
-    : await equiposService.getAll()
-  // Fallback a todos los equipos si no hay ninguno vinculado a la temporada
-  if (equipos.length === 0) {
-    equipos = await equiposService.getAll()
-  }
+interface SectionCardsProps {
+  stats: SectionCardsStats
+}
 
-  const jugadores = (
-    await Promise.all(equipos.map((e: any) => jugadoresService.getByEquipo(e.id)))
-  ).flat()
-
-  const asistencias = (
-    await Promise.all(equipos.map((e: any) => asistenciasService.getByEquipo(e.id)))
-  ).flat() as Asistencia[]
-
-  const valoraciones = (
-    await Promise.all(jugadores.map((j: any) => valoracionesService.getByJugador(j.id)))
-  ).flat()
-
-  const objetivos = (
-    await Promise.all(equipos.map((e: any) => objetivosService.getByEquipo(e.id)))
-  ).flat()
-
-  const asistenciaPromedio =
-    asistencias.length > 0
-      ? `${(
-          (asistencias.filter((a: Asistencia) => a.asistio).length / asistencias.length) *
-          100
-        ).toFixed(0)}%`
-      : "0%"
-
-  // Promedio de valoraciones a partir de aptitudes numéricas (ignorando vacías/0)
-  const valoracionesPromedio = valoraciones
-    .map((v: any) => {
-      const values = Object.values(v.aptitudes || {}).map(Number).filter((n) => !isNaN(n))
-      if (values.length === 0 || values.every((n) => n === 0)) return null
-      return values.reduce((a, b) => a + b, 0) / values.length
-    })
-    .filter((n) => n !== null) as number[]
-
-  const valoracionMedia =
-    valoracionesPromedio.length > 0
-      ? (
-          valoracionesPromedio.reduce((sum, n) => sum + n, 0) /
-          valoracionesPromedio.length
-        ).toFixed(1)
-      : "0"
-
-  const objetivosCompletados =
-    objetivos.length > 0
-      ? `${(
-          (objetivos.filter((o: any) => o.progreso >= 100).length / objetivos.length) *
-          100
-        ).toFixed(0)}%`
-      : "0%"
-
-  const temporadaLabel = temporada?.id ?? "N/A"
+export function SectionCards({ stats }: SectionCardsProps) {
+  const {
+    temporadaLabel,
+    totalTeams,
+    totalPlayers,
+    attendanceAverage,
+    attendanceRecords,
+    ratingAverage,
+    ratingRecords,
+    objectivesCompletion,
+    objectivesCount,
+  } = stats
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 px-4 lg:px-6 *:data-[slot=card]:shadow-xs *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card">
@@ -87,12 +43,12 @@ export async function SectionCards() {
         <CardHeader className="relative">
           <CardDescription>Total Jugadores</CardDescription>
           <CardTitle className="@[250px]/card:text-3xl text-2xl font-semibold tabular-nums">
-            {jugadores.length}
+            {totalPlayers}
           </CardTitle>
           <div className="absolute right-4 top-4">
             <Badge variant="outline" className="flex gap-1 rounded-lg text-xs">
               <UsersIcon className="size-3" />
-              {equipos.length} Equipos
+              {totalTeams} Equipos
             </Badge>
           </div>
         </CardHeader>
@@ -108,12 +64,12 @@ export async function SectionCards() {
         <CardHeader className="relative">
           <CardDescription>Asistencia Promedio</CardDescription>
           <CardTitle className="@[250px]/card:text-3xl text-2xl font-semibold tabular-nums">
-            {asistenciaPromedio}
+            {attendanceAverage}
           </CardTitle>
           <div className="absolute right-4 top-4">
             <Badge variant="outline" className="flex gap-1 rounded-lg text-xs">
               <ClipboardCheckIcon className="size-3" />
-              {asistencias.length} regs
+              {attendanceRecords} regs
             </Badge>
           </div>
         </CardHeader>
@@ -129,12 +85,12 @@ export async function SectionCards() {
         <CardHeader className="relative">
           <CardDescription>Valoración Media</CardDescription>
           <CardTitle className="@[250px]/card:text-3xl text-2xl font-semibold tabular-nums">
-            {valoracionMedia}
+            {ratingAverage}
           </CardTitle>
           <div className="absolute right-4 top-4">
             <Badge variant="outline" className="flex gap-1 rounded-lg text-xs">
               <StarIcon className="size-3" />
-              {valoraciones.length} regs
+              {ratingRecords} regs
             </Badge>
           </div>
         </CardHeader>
@@ -150,12 +106,12 @@ export async function SectionCards() {
         <CardHeader className="relative">
           <CardDescription>Objetivos Cumplidos</CardDescription>
           <CardTitle className="@[250px]/card:text-3xl text-2xl font-semibold tabular-nums">
-            {objetivosCompletados}
+            {objectivesCompletion}
           </CardTitle>
           <div className="absolute right-4 top-4">
             <Badge variant="outline" className="flex gap-1 rounded-lg text-xs">
               <TrendingUpIcon className="size-3" />
-              {objetivos.length} regs
+              {objectivesCount} regs
             </Badge>
           </div>
         </CardHeader>


### PR DESCRIPTION
## Summary
- calculate season-wide attendance, ratings, and objectives on the dashboard page
- pass the live metrics into the summary cards component instead of fetching internally
- force the dashboard route to render dynamically so the cards stay in sync with the database

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119f3faf1883208c323ac11a3b77fb)